### PR TITLE
Encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -851,6 +851,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proxmox-api-encode"
+version = "0.1.0"
+dependencies = [
+ "percent-encoding",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -144,6 +159,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-targets 0.52.5",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,7 +190,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
+ "strsim 0.11.1",
 ]
 
 [[package]]
@@ -227,6 +255,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54e36fcd13ed84ffdfda6f5be89b31287cbb80c439841fe69e04841435464391"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c2cf1c23a687a1feeb728783b993c4e1ad83d99f351801977dd809b48d0a70f"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+ "serde",
 ]
 
 [[package]]
@@ -406,12 +479,18 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap",
+ "indexmap 2.2.6",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -430,6 +509,12 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -534,6 +619,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -545,12 +659,24 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.14.3",
+ "serde",
 ]
 
 [[package]]
@@ -677,6 +803,21 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -816,6 +957,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "pretty_env_logger"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -857,6 +1004,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "serde_derive",
+ "serde_with",
 ]
 
 [[package]]
@@ -1112,6 +1260,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ad483d2ab0149d5a5ebcd9972a3852711e0153d863bf5a5d0391d28883c4a20"
+dependencies = [
+ "base64",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.2.6",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65569b702f41443e8bc8bbb1c5779bd0450bbe723b56198980e80ec45780bce2"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1141,6 +1319,12 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strsim"
@@ -1211,6 +1395,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "time"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -1519,6 +1734,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.5",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ["generator", "proxmox-api"]
+members = ["generator", "proxmox-api", "proxmox-api-encode"]
 resolver = "2"

--- a/proxmox-api-encode/Cargo.toml
+++ b/proxmox-api-encode/Cargo.toml
@@ -11,3 +11,4 @@ percent-encoding = "2.3.1"
 
 [dev-dependencies]
 serde_derive = "1"
+serde_with={ version = "3.8.1"}

--- a/proxmox-api-encode/Cargo.toml
+++ b/proxmox-api-encode/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "proxmox-api-encode"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+serde = "1.0.197"
+percent-encoding = "2.3.1"
+
+[dev-dependencies]
+serde_derive = "1"

--- a/proxmox-api-encode/src/de/inner.rs
+++ b/proxmox-api-encode/src/de/inner.rs
@@ -95,11 +95,12 @@ impl<'de> Deserializer<'de> {
 impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     type Error = Error;
 
-    fn deserialize_any<V>(self, _visitor: V) -> Result<V::Value>
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        unimplemented!()
+        let s = self.parse_string()?;
+        visitor.visit_str(s)
     }
 
     fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value>

--- a/proxmox-api-encode/src/de/inner.rs
+++ b/proxmox-api-encode/src/de/inner.rs
@@ -1,0 +1,435 @@
+use std::ops::{AddAssign, MulAssign, Neg};
+use std::str::FromStr;
+
+use percent_encoding::percent_decode_str;
+use serde::de::{self, DeserializeSeed, IntoDeserializer, MapAccess, SeqAccess, Visitor};
+use serde::Deserialize;
+
+use error::{Error, Result};
+
+use crate::error;
+
+pub struct Deserializer<'de> {
+    input: &'de str,
+}
+
+impl<'de> Deserializer<'de> {
+    pub fn from_str(input: &'de str) -> Self {
+        Deserializer { input }
+    }
+}
+pub fn from_str<'a, T>(s: &'a str) -> Result<T>
+where
+    T: Deserialize<'a>,
+{
+    let mut deserializer = Deserializer::from_str(s);
+    let t = T::deserialize(&mut deserializer)?;
+    if deserializer.input.is_empty() {
+        Ok(t)
+    } else {
+        Err(Error::Message("WrongCharacter".into()))
+    }
+}
+impl<'de> Deserializer<'de> {
+    fn peek_char(&mut self) -> Result<char> {
+        self.input.chars().next().ok_or(Error::Eof)
+    }
+    fn next_three_str(&mut self) -> Result<&'de str> {
+        let s = &self.input[0..3];
+        self.input = &self.input[s.len()..];
+        Ok(s)
+    }
+    fn parse_bool(&mut self) -> Result<bool> {
+        if self.input.starts_with("1") {
+            self.input = &self.input["1".len()..];
+            Ok(true)
+        } else if self.input.starts_with("0") {
+            self.input = &self.input["0".len()..];
+            Ok(false)
+        } else {
+            Err(Error::Message("ExpectedBoolean".into()))
+        }
+    }
+    fn parse_unsigned<T>(&mut self) -> Result<T>
+    where
+        T: AddAssign<T> + MulAssign<T> + From<u8> + FromStr,
+    {
+        match self.parse_string().unwrap().parse::<T>() {
+            Ok(v) => Ok(v),
+            Err(_) => Err(Error::Message("invalid number".into())),
+        }
+    }
+
+    fn parse_signed<T>(&mut self) -> Result<T>
+    where
+        T: Neg<Output = T> + AddAssign<T> + MulAssign<T> + From<i8> + FromStr,
+    {
+        match self.parse_string().unwrap().parse::<T>() {
+            Ok(v) => Ok(v),
+            Err(_) => Err(Error::Message("invalid number".into())),
+        }
+    }
+
+    fn parse_string(&mut self) -> Result<&'de str> {
+        let eq = self.input.find("%3D");
+        let comma = self.input.find("%2C");
+        let target = if eq.is_none() && comma.is_none() {
+            self.input.len()
+        } else if comma.is_none() || (eq.is_some() && (eq.unwrap() < comma.unwrap())) {
+            eq.unwrap()
+        } else {
+            comma.unwrap()
+        };
+        let s = &self.input[..target];
+        self.input = &self.input[target..];
+        Ok(s)
+    }
+    fn parse_seq_element(&mut self) -> Result<&'de str> {
+        let target = self.input.find("%3B").unwrap_or(self.input.len());
+        let s = &self.input[..target];
+        self.input = &self.input[target..];
+        Ok(s)
+    }
+}
+
+impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
+    type Error = Error;
+
+    fn deserialize_any<V>(self, _visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        unimplemented!()
+    }
+
+    fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_bool(self.parse_bool()?)
+    }
+
+    fn deserialize_i8<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_i8(self.parse_signed()?)
+    }
+
+    fn deserialize_i16<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_i16(self.parse_signed()?)
+    }
+
+    fn deserialize_i32<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_i32(self.parse_signed()?)
+    }
+
+    fn deserialize_i64<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_i64(self.parse_signed()?)
+    }
+
+    fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_u8(self.parse_unsigned()?)
+    }
+
+    fn deserialize_u16<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_u16(self.parse_unsigned()?)
+    }
+
+    fn deserialize_u32<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_u32(self.parse_unsigned()?)
+    }
+
+    fn deserialize_u64<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_u64(self.parse_unsigned()?)
+    }
+
+    // Float parsing is stupidly hard.
+    fn deserialize_f32<V>(self, _visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        unimplemented!()
+    }
+
+    // Float parsing is stupidly hard.
+    fn deserialize_f64<V>(self, _visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        unimplemented!()
+    }
+
+    fn deserialize_char<V>(self, _visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        unimplemented!()
+    }
+
+    fn deserialize_str<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_str(self.parse_string()?)
+    }
+
+    fn deserialize_string<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_string(
+            percent_decode_str(self.parse_string()?)
+                .decode_utf8()
+                .unwrap()
+                .to_string(),
+        )
+    }
+
+    fn deserialize_bytes<V>(self, _visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        unimplemented!()
+    }
+
+    fn deserialize_byte_buf<V>(self, _visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        unimplemented!()
+    }
+
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        if self.input.starts_with("null") {
+            self.input = &self.input["null".len()..];
+            visitor.visit_none()
+        } else {
+            visitor.visit_some(self)
+        }
+    }
+
+    fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        if self.input.starts_with("null") {
+            self.input = &self.input["null".len()..];
+            visitor.visit_unit()
+        } else {
+            Err(Error::Message("ExpectedNull".into()))
+        }
+    }
+
+    fn deserialize_unit_struct<V>(self, _name: &'static str, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_unit(visitor)
+    }
+
+    fn deserialize_newtype_struct<V>(self, _name: &'static str, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_newtype_struct(self)
+    }
+
+    fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_seq(CommaSeparated::new(self))
+    }
+
+    fn deserialize_tuple<V>(self, _len: usize, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_seq(visitor)
+    }
+
+    // Tuple structs look just like sequences in JSON.
+    fn deserialize_tuple_struct<V>(
+        self,
+        _name: &'static str,
+        _len: usize,
+        visitor: V,
+    ) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_seq(visitor)
+    }
+    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        Ok(visitor.visit_map(CommaSeparated::new(self))?)
+    }
+
+    fn deserialize_struct<V>(
+        self,
+        _name: &'static str,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_map(visitor)
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_enum(self.parse_string()?.into_deserializer())
+    }
+
+    fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_str(visitor)
+    }
+
+    fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_any(visitor)
+    }
+}
+
+struct CommaSeparated<'a, 'de: 'a> {
+    de: &'a mut Deserializer<'de>,
+    first: bool,
+}
+
+impl<'a, 'de> CommaSeparated<'a, 'de> {
+    fn new(de: &'a mut Deserializer<'de>) -> Self {
+        CommaSeparated { de, first: true }
+    }
+}
+
+impl<'de, 'a> SeqAccess<'de> for CommaSeparated<'a, 'de> {
+    type Error = Error;
+
+    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        if self.de.peek_char().is_err() {
+            return Ok(None);
+        }
+        if !self.first && self.de.next_three_str()? != "%3B" {
+            return Err(Error::Message("ExpectedArrayComma".into()));
+        }
+        self.first = false;
+        let s = self.de.parse_seq_element()?;
+        let mut de = Deserializer::from_str(s);
+        seed.deserialize(&mut de).map(Some)
+    }
+}
+
+impl<'de, 'a> MapAccess<'de> for CommaSeparated<'a, 'de> {
+    type Error = Error;
+
+    fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>>
+    where
+        K: DeserializeSeed<'de>,
+    {
+        if self.de.peek_char().is_err() {
+            return Ok(None);
+        }
+        if !self.first && self.de.next_three_str()? != "%2C" {
+            return Err(Error::Message("ExpectedAnd".into()));
+        }
+        self.first = false;
+        seed.deserialize(&mut *self.de).map(Some)
+    }
+
+    fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value>
+    where
+        V: DeserializeSeed<'de>,
+    {
+        if self.de.next_three_str()? != "%3D" {
+            return Err(Error::Message("ExpectedEqual".into()));
+        }
+        seed.deserialize(&mut *self.de)
+    }
+
+    fn next_key<K>(&mut self) -> std::prelude::v1::Result<Option<K>, Self::Error>
+    where
+        K: Deserialize<'de>,
+    {
+        self.next_key_seed(std::marker::PhantomData)
+    }
+
+    fn next_value<V>(&mut self) -> std::prelude::v1::Result<V, Self::Error>
+    where
+        V: Deserialize<'de>,
+    {
+        self.next_value_seed(std::marker::PhantomData)
+    }
+
+    fn next_entry<K, V>(&mut self) -> std::prelude::v1::Result<Option<(K, V)>, Self::Error>
+    where
+        K: Deserialize<'de>,
+        V: Deserialize<'de>,
+    {
+        self.next_entry_seed(std::marker::PhantomData, std::marker::PhantomData)
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        None
+    }
+
+    fn next_entry_seed<K, V>(
+        &mut self,
+        kseed: K,
+        vseed: V,
+    ) -> std::prelude::v1::Result<Option<(K::Value, V::Value)>, Self::Error>
+    where
+        K: DeserializeSeed<'de>,
+        V: DeserializeSeed<'de>,
+    {
+        match self.next_key_seed(kseed)? {
+            Some(key) => {
+                let value = self.next_value_seed(vseed)?;
+                Ok(Some((key, value)))
+            }
+            None => Ok(None),
+        }
+    }
+}

--- a/proxmox-api-encode/src/de/mod.rs
+++ b/proxmox-api-encode/src/de/mod.rs
@@ -1,0 +1,461 @@
+pub mod inner;
+use std::ops::{AddAssign, MulAssign, Neg};
+
+use serde::de::{self, DeserializeSeed, MapAccess, SeqAccess, Visitor};
+use serde::Deserialize;
+
+use error::{Error, Result};
+
+use inner::Deserializer as InnerDeserializer;
+
+use crate::error;
+
+pub struct Deserializer<'de> {
+    input: &'de str,
+}
+
+impl<'de> Deserializer<'de> {
+    pub fn from_str(input: &'de str) -> Self {
+        Deserializer { input }
+    }
+}
+pub fn from_str<'a, T>(s: &'a str) -> Result<T>
+where
+    T: Deserialize<'a>,
+{
+    let mut deserializer = Deserializer::from_str(s);
+    let t = T::deserialize(&mut deserializer)?;
+    if deserializer.input.is_empty() {
+        Ok(t)
+    } else {
+        Err(Error::Message("WrongCharacter".into()))
+    }
+}
+impl<'de> Deserializer<'de> {
+    fn peek_char(&mut self) -> Result<char> {
+        self.input.chars().next().ok_or(Error::Eof)
+    }
+
+    fn next_char(&mut self) -> Result<char> {
+        let ch = self.peek_char()?;
+        self.input = &self.input[ch.len_utf8()..];
+        Ok(ch)
+    }
+    fn parse_bool(&mut self) -> Result<bool> {
+        if self.input.starts_with("1") {
+            self.input = &self.input["1".len()..];
+            Ok(true)
+        } else if self.input.starts_with("0") {
+            self.input = &self.input["0".len()..];
+            Ok(false)
+        } else {
+            Err(Error::Message("ExpectedBoolean".into()))
+        }
+    }
+    fn parse_unsigned<T>(&mut self) -> Result<T>
+    where
+        T: AddAssign<T> + MulAssign<T> + From<u8>,
+    {
+        let mut int = match self.next_char()? {
+            ch @ '0'..='9' => T::from(ch as u8 - b'0'),
+            _ => {
+                return Err(Error::Message("ExpectedInteger".into()));
+            }
+        };
+        loop {
+            match self.input.chars().next() {
+                Some(ch @ '0'..='9') => {
+                    self.input = &self.input[1..];
+                    int *= T::from(10);
+                    int += T::from(ch as u8 - b'0');
+                }
+                _ => {
+                    return Ok(int);
+                }
+            }
+        }
+    }
+
+    fn parse_signed<T>(&mut self) -> Result<T>
+    where
+        T: Neg<Output = T> + AddAssign<T> + MulAssign<T> + From<i8>,
+    {
+        unimplemented!()
+    }
+
+    fn parse_string(&mut self) -> Result<&'de str> {
+        match self.input.find(|v| ['=', '&'].contains(&v)) {
+            Some(len) => {
+                let s = &self.input[..len];
+                self.input = &self.input[len..];
+                Ok(s)
+            }
+            None => {
+                let s = &self.input[..];
+                self.input = &self.input[s.len()..];
+                Ok(s)
+            }
+        }
+    }
+}
+
+impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
+    type Error = Error;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        match self.peek_char()? {
+            'n' => self.deserialize_unit(visitor),
+            't' | 'f' => self.deserialize_bool(visitor),
+            '"' => self.deserialize_str(visitor),
+            '0'..='9' => self.deserialize_u64(visitor),
+            '-' => self.deserialize_i64(visitor),
+            '[' => self.deserialize_seq(visitor),
+            '{' => self.deserialize_map(visitor),
+            _ => Err(Error::Message("Syntax".into())),
+        }
+    }
+
+    fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_bool(self.parse_bool()?)
+    }
+
+    fn deserialize_i8<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_i8(self.parse_signed()?)
+    }
+
+    fn deserialize_i16<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_i16(self.parse_signed()?)
+    }
+
+    fn deserialize_i32<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_i32(self.parse_signed()?)
+    }
+
+    fn deserialize_i64<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_i64(self.parse_signed()?)
+    }
+
+    fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_u8(self.parse_unsigned()?)
+    }
+
+    fn deserialize_u16<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_u16(self.parse_unsigned()?)
+    }
+
+    fn deserialize_u32<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_u32(self.parse_unsigned()?)
+    }
+
+    fn deserialize_u64<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_u64(self.parse_unsigned()?)
+    }
+
+    // Float parsing is stupidly hard.
+    fn deserialize_f32<V>(self, _visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        unimplemented!()
+    }
+
+    // Float parsing is stupidly hard.
+    fn deserialize_f64<V>(self, _visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        unimplemented!()
+    }
+
+    // The `Serializer` implementation on the previous page serialized chars as
+    // single-character strings so handle that representation here.
+    fn deserialize_char<V>(self, _visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        // Parse a string, check that it is one character, call `visit_char`.
+        unimplemented!()
+    }
+
+    fn deserialize_str<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_borrowed_str(self.parse_string()?)
+    }
+
+    fn deserialize_string<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_str(visitor)
+    }
+
+    fn deserialize_bytes<V>(self, _visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        unimplemented!()
+    }
+
+    fn deserialize_byte_buf<V>(self, _visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        unimplemented!()
+    }
+
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        if self.input.starts_with("null") {
+            self.input = &self.input["null".len()..];
+            visitor.visit_none()
+        } else {
+            visitor.visit_some(self)
+        }
+    }
+
+    fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        if self.input.starts_with("null") {
+            self.input = &self.input["null".len()..];
+            visitor.visit_unit()
+        } else {
+            Err(Error::Message("ExpectedNull".into()))
+        }
+    }
+
+    fn deserialize_unit_struct<V>(self, _name: &'static str, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_unit(visitor)
+    }
+
+    fn deserialize_newtype_struct<V>(self, _name: &'static str, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_newtype_struct(self)
+    }
+
+    fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        if self.next_char()? == '[' {
+            let value = visitor.visit_seq(CommaSeparated::new(self))?;
+            if self.next_char()? == ']' {
+                Ok(value)
+            } else {
+                Err(Error::Message("ExpectedArrayEnd".into()))
+            }
+        } else {
+            Err(Error::Message("ExpectedArray".into()))
+        }
+    }
+
+    fn deserialize_tuple<V>(self, _len: usize, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_seq(visitor)
+    }
+
+    // Tuple structs look just like sequences in JSON.
+    fn deserialize_tuple_struct<V>(
+        self,
+        _name: &'static str,
+        _len: usize,
+        visitor: V,
+    ) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_seq(visitor)
+    }
+    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        Ok(visitor.visit_map(CommaSeparated::new(self))?)
+    }
+
+    fn deserialize_struct<V>(
+        self,
+        _name: &'static str,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_map(visitor)
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        _visitor: V,
+    ) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        unimplemented!()
+    }
+
+    fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_str(visitor)
+    }
+
+    fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_any(visitor)
+    }
+}
+
+struct CommaSeparated<'a, 'de: 'a> {
+    de: &'a mut Deserializer<'de>,
+    first: bool,
+}
+
+impl<'a, 'de> CommaSeparated<'a, 'de> {
+    fn new(de: &'a mut Deserializer<'de>) -> Self {
+        CommaSeparated { de, first: true }
+    }
+}
+
+impl<'de, 'a> SeqAccess<'de> for CommaSeparated<'a, 'de> {
+    type Error = Error;
+
+    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        // Check if there are no more elements.
+        if self.de.peek_char().is_err() {
+            return Ok(None);
+        }
+        // Comma is required before every element except the first.
+        if !self.first && self.de.next_char()? != ';' {
+            return Err(Error::Message("ExpectedArrayComma".into()));
+        }
+        self.first = false;
+        seed.deserialize(&mut *self.de).map(Some)
+    }
+}
+
+impl<'de, 'a> MapAccess<'de> for CommaSeparated<'a, 'de> {
+    type Error = Error;
+
+    fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>>
+    where
+        K: DeserializeSeed<'de>,
+    {
+        if self.de.peek_char().is_err() {
+            return Ok(None);
+        }
+
+        if !self.first && self.de.next_char()? != '&' {
+            return Err(Error::Message("ExpectedAnd".into()));
+        }
+        self.first = false;
+        seed.deserialize(&mut *self.de).map(Some)
+    }
+
+    fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value>
+    where
+        V: DeserializeSeed<'de>,
+    {
+        if self.de.next_char()? != '=' {
+            return Err(Error::Message("ExpectedEqual".into()));
+        }
+        let s = self.de.parse_string();
+        let mut de = InnerDeserializer::from_str(s.unwrap());
+        seed.deserialize(&mut de)
+    }
+
+    fn next_key<K>(&mut self) -> std::prelude::v1::Result<Option<K>, Self::Error>
+    where
+        K: Deserialize<'de>,
+    {
+        self.next_key_seed(std::marker::PhantomData)
+    }
+
+    fn next_value<V>(&mut self) -> std::prelude::v1::Result<V, Self::Error>
+    where
+        V: Deserialize<'de>,
+    {
+        self.next_value_seed(std::marker::PhantomData)
+    }
+
+    fn next_entry<K, V>(&mut self) -> std::prelude::v1::Result<Option<(K, V)>, Self::Error>
+    where
+        K: Deserialize<'de>,
+        V: Deserialize<'de>,
+    {
+        self.next_entry_seed(std::marker::PhantomData, std::marker::PhantomData)
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        None
+    }
+
+    fn next_entry_seed<K, V>(
+        &mut self,
+        kseed: K,
+        vseed: V,
+    ) -> std::prelude::v1::Result<Option<(K::Value, V::Value)>, Self::Error>
+    where
+        K: DeserializeSeed<'de>,
+        V: DeserializeSeed<'de>,
+    {
+        match self.next_key_seed(kseed)? {
+            Some(key) => {
+                let value = self.next_value_seed(vseed)?;
+                Ok(Some((key, value)))
+            }
+            None => Ok(None),
+        }
+    }
+}

--- a/proxmox-api-encode/src/error.rs
+++ b/proxmox-api-encode/src/error.rs
@@ -1,0 +1,39 @@
+use std;
+use std::fmt::{self, Display};
+
+use serde::{de, ser};
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug)]
+pub enum Error {
+    Message(String),
+    Unsupported(String),
+    Eof,
+    Null,
+}
+
+impl ser::Error for Error {
+    fn custom<T: Display>(msg: T) -> Self {
+        Error::Message(msg.to_string())
+    }
+}
+
+impl de::Error for Error {
+    fn custom<T: Display>(msg: T) -> Self {
+        Error::Message(msg.to_string())
+    }
+}
+
+impl Display for Error {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Error::Message(msg) => formatter.write_str(msg),
+            Error::Unsupported(msg) => formatter.write_str(msg),
+            Error::Eof => formatter.write_str("unexpected end of input"),
+            Error::Null => formatter.write_str("null value"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}

--- a/proxmox-api-encode/src/lib.rs
+++ b/proxmox-api-encode/src/lib.rs
@@ -1,3 +1,6 @@
+use percent_encoding::AsciiSet;
+use percent_encoding::CONTROLS;
+
 pub mod de;
 pub mod error;
 pub mod ser;
@@ -5,6 +8,8 @@ pub mod ser;
 pub trait DefaultKey {
     fn default_key() -> String;
 }
+
+pub const CUSTOM_ENCODING_SET: &AsciiSet = &CONTROLS.add(b'/').add(b',').add(b':').add(b';').add(b'=');
 
 #[cfg(test)]
 mod test;

--- a/proxmox-api-encode/src/lib.rs
+++ b/proxmox-api-encode/src/lib.rs
@@ -1,0 +1,10 @@
+pub mod de;
+pub mod error;
+pub mod ser;
+
+pub trait DefaultKey {
+    fn default_key() -> String;
+}
+
+#[cfg(test)]
+mod test;

--- a/proxmox-api-encode/src/ser/inner.rs
+++ b/proxmox-api-encode/src/ser/inner.rs
@@ -1,5 +1,8 @@
-use crate::error::{Error, Result};
-use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
+use crate::{
+    error::{Error, Result},
+    CUSTOM_ENCODING_SET,
+};
+use percent_encoding::utf8_percent_encode;
 use serde::{ser, Serialize};
 
 pub struct Serializer {
@@ -291,8 +294,29 @@ impl<'a> ser::SerializeMap for &'a mut Serializer {
         value.serialize(&mut **self)
     }
 
+    fn serialize_entry<K: ?Sized, V: ?Sized>(
+        &mut self,
+        key: &K,
+        value: &V,
+    ) -> std::prelude::v1::Result<(), Self::Error>
+    where
+        K: Serialize,
+        V: Serialize,
+    {
+        let v_s = inner_to_string(&value);
+        if v_s.is_ok() {
+            match self.serialize_key(key) {
+                Ok(val) => val,
+                Err(err) => return Err(err),
+            };
+            self.output += "=";
+            v_s.unwrap().serialize(&mut **self)?;
+        }
+        Ok(())
+    }
+
     fn end(self) -> Result<Self::Ok> {
-        self.output = utf8_percent_encode(&self.output, NON_ALPHANUMERIC).to_string();
+        self.output = utf8_percent_encode(&self.output, CUSTOM_ENCODING_SET).to_string();
         Ok(())
     }
 }
@@ -305,16 +329,21 @@ impl<'a> ser::SerializeStruct for &'a mut Serializer {
     where
         T: ?Sized + Serialize,
     {
-        if !self.output.is_empty() {
-            self.output += ",";
+        let value = inner_to_string(&value);
+        if value.is_ok() {
+            if !self.output.is_empty() {
+                self.output += ",";
+            }
+            key.serialize(&mut **self)?;
+            self.output += "=";
+            value.unwrap().serialize(&mut **self).unwrap();
         }
-        key.serialize(&mut **self)?;
-        self.output += "=";
-        value.serialize(&mut **self)
+
+        Ok(())
     }
 
     fn end(self) -> Result<Self::Ok> {
-        self.output = utf8_percent_encode(&self.output, NON_ALPHANUMERIC).to_string();
+        self.output = utf8_percent_encode(&self.output, CUSTOM_ENCODING_SET).to_string();
         Ok(())
     }
 }

--- a/proxmox-api-encode/src/ser/inner.rs
+++ b/proxmox-api-encode/src/ser/inner.rs
@@ -1,0 +1,341 @@
+use crate::error::{Error, Result};
+use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
+use serde::{ser, Serialize};
+
+pub struct Serializer {
+    output: String,
+}
+
+pub fn inner_to_string<T>(value: &T) -> Result<String>
+where
+    T: Serialize,
+{
+    let mut serializer = Serializer {
+        output: String::new(),
+    };
+    value.serialize(&mut serializer)?;
+    Ok(serializer.output)
+}
+
+impl<'a> ser::Serializer for &'a mut Serializer {
+    type Ok = ();
+    type Error = Error;
+    type SerializeSeq = Self;
+    type SerializeTuple = Self;
+    type SerializeTupleStruct = Self;
+    type SerializeTupleVariant = Self;
+    type SerializeMap = Self;
+    type SerializeStruct = Self;
+    type SerializeStructVariant = Self;
+
+    fn serialize_bool(self, v: bool) -> Result<Self::Ok> {
+        self.output += if v { "1" } else { "0" };
+        Ok(())
+    }
+
+    fn serialize_i8(self, v: i8) -> Result<Self::Ok> {
+        self.serialize_i128(i128::from(v))
+    }
+
+    fn serialize_i16(self, v: i16) -> Result<Self::Ok> {
+        self.serialize_i128(i128::from(v))
+    }
+
+    fn serialize_i32(self, v: i32) -> Result<Self::Ok> {
+        self.serialize_i128(i128::from(v))
+    }
+
+    fn serialize_i64(self, v: i64) -> Result<Self::Ok> {
+        self.serialize_i128(i128::from(v))
+    }
+
+    fn serialize_i128(self, v: i128) -> Result<Self::Ok> {
+        self.output += &v.to_string();
+        Ok(())
+    }
+
+    fn serialize_u8(self, v: u8) -> Result<Self::Ok> {
+        self.serialize_u128(u128::from(v))
+    }
+
+    fn serialize_u16(self, v: u16) -> Result<Self::Ok> {
+        self.serialize_u128(u128::from(v))
+    }
+
+    fn serialize_u32(self, v: u32) -> Result<Self::Ok> {
+        self.serialize_u128(u128::from(v))
+    }
+
+    fn serialize_u64(self, v: u64) -> Result<Self::Ok> {
+        self.serialize_u128(u128::from(v))
+    }
+
+    fn serialize_u128(self, v: u128) -> Result<Self::Ok> {
+        self.output += &v.to_string();
+        Ok(())
+    }
+
+    fn serialize_f32(self, v: f32) -> Result<Self::Ok> {
+        self.serialize_f64(f64::from(v))
+    }
+
+    fn serialize_f64(self, v: f64) -> Result<Self::Ok> {
+        self.output += &v.to_string();
+        Ok(())
+    }
+
+    fn serialize_char(self, v: char) -> Result<Self::Ok> {
+        self.serialize_str(&v.to_string())
+    }
+
+    fn serialize_str(self, v: &str) -> Result<Self::Ok> {
+        self.output += v;
+        Ok(())
+    }
+
+    fn serialize_bytes(self, v: &[u8]) -> Result<Self::Ok> {
+        use serde::ser::SerializeSeq;
+        let mut seq = self.serialize_seq(Some(v.len()))?;
+        for byte in v {
+            seq.serialize_element(byte)?;
+        }
+        seq.end()
+    }
+
+    fn serialize_none(self) -> Result<Self::Ok> {
+        self.serialize_unit()
+    }
+
+    fn serialize_some<T>(self, value: &T) -> Result<Self::Ok>
+    where
+        T: ?Sized + Serialize,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_unit(self) -> Result<Self::Ok> {
+        Err(Error::Null)
+    }
+
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok> {
+        self.serialize_unit()
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+    ) -> Result<Self::Ok> {
+        self.serialize_str(variant)
+    }
+
+    fn serialize_newtype_struct<T>(self, _name: &'static str, value: &T) -> Result<Self::Ok>
+    where
+        T: ?Sized + Serialize,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_newtype_variant<T>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _value: &T,
+    ) -> Result<Self::Ok>
+    where
+        T: ?Sized + Serialize,
+    {
+        Err(Error::Unsupported("Tuple variant filed".into()))
+    }
+
+    fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq> {
+        Ok(self)
+    }
+
+    fn serialize_tuple(self, len: usize) -> Result<Self::SerializeTuple> {
+        self.serialize_seq(Some(len))
+    }
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeTupleStruct> {
+        self.serialize_seq(Some(len))
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleVariant> {
+        Err(Error::Unsupported("Tuple variant filed".into()))
+    }
+
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap> {
+        Ok(self)
+    }
+
+    fn serialize_struct(self, _name: &'static str, len: usize) -> Result<Self::SerializeStruct> {
+        self.serialize_map(Some(len))
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant> {
+        variant.serialize(&mut *self)?;
+        Ok(self)
+    }
+}
+
+impl<'a> ser::SerializeSeq for &'a mut Serializer {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_element<T>(&mut self, value: &T) -> Result<Self::Ok>
+    where
+        T: ?Sized + Serialize,
+    {
+        if !self.output.is_empty() {
+            self.output += ";";
+        }
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<Self::Ok> {
+        Ok(())
+    }
+}
+
+impl<'a> ser::SerializeTuple for &'a mut Serializer {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_element<T>(&mut self, value: &T) -> Result<Self::Ok>
+    where
+        T: ?Sized + Serialize,
+    {
+        if !self.output.is_empty() {
+            self.output += ";";
+        }
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<Self::Ok> {
+        Ok(())
+    }
+}
+
+impl<'a> ser::SerializeTupleStruct for &'a mut Serializer {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, value: &T) -> Result<Self::Ok>
+    where
+        T: ?Sized + Serialize,
+    {
+        if !self.output.is_empty() {
+            self.output += ";";
+        }
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<Self::Ok> {
+        Ok(())
+    }
+}
+
+impl<'a> ser::SerializeTupleVariant for &'a mut Serializer {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, value: &T) -> Result<Self::Ok>
+    where
+        T: ?Sized + Serialize,
+    {
+        if !self.output.is_empty() {
+            self.output += ";";
+        }
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<Self::Ok> {
+        Ok(())
+    }
+}
+impl<'a> ser::SerializeMap for &'a mut Serializer {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_key<T>(&mut self, key: &T) -> Result<Self::Ok>
+    where
+        T: ?Sized + Serialize,
+    {
+        if !self.output.is_empty() {
+            self.output += ",";
+        }
+        key.serialize(&mut **self)
+    }
+    fn serialize_value<T>(&mut self, value: &T) -> Result<Self::Ok>
+    where
+        T: ?Sized + Serialize,
+    {
+        self.output += "=";
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<Self::Ok> {
+        self.output = utf8_percent_encode(&self.output, NON_ALPHANUMERIC).to_string();
+        Ok(())
+    }
+}
+
+impl<'a> ser::SerializeStruct for &'a mut Serializer {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<Self::Ok>
+    where
+        T: ?Sized + Serialize,
+    {
+        if !self.output.is_empty() {
+            self.output += ",";
+        }
+        key.serialize(&mut **self)?;
+        self.output += "=";
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<Self::Ok> {
+        self.output = utf8_percent_encode(&self.output, NON_ALPHANUMERIC).to_string();
+        Ok(())
+    }
+}
+
+impl<'a> ser::SerializeStructVariant for &'a mut Serializer {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<Self::Ok>
+    where
+        T: ?Sized + Serialize,
+    {
+        if !self.output.is_empty() {
+            self.output += ",";
+        }
+        key.serialize(&mut **self)?;
+        self.output += "=";
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<Self::Ok> {
+        Ok(())
+    }
+}

--- a/proxmox-api-encode/src/ser/mod.rs
+++ b/proxmox-api-encode/src/ser/mod.rs
@@ -1,0 +1,240 @@
+pub mod inner;
+
+use crate::error::{Error, Result};
+use inner::inner_to_string;
+use serde::{ser, Serialize};
+
+pub struct Serializer {
+    output: String,
+}
+
+pub fn to_string<T>(value: &T) -> Result<String>
+where
+    T: Serialize,
+{
+    let mut serializer = Serializer {
+        output: String::new(),
+    };
+    value.serialize(&mut serializer)?;
+    Ok(serializer.output)
+}
+
+impl<'a> ser::Serializer for &'a mut Serializer {
+    type Ok = ();
+    type Error = Error;
+    type SerializeSeq = ser::Impossible<(), Error>;
+    type SerializeTuple = ser::Impossible<(), Error>;
+    type SerializeTupleStruct = ser::Impossible<(), Error>;
+    type SerializeTupleVariant = ser::Impossible<(), Error>;
+    type SerializeMap = Self;
+    type SerializeStruct = Self;
+    type SerializeStructVariant = ser::Impossible<(), Error>;
+
+    fn serialize_bool(self, v: bool) -> Result<Self::Ok> {
+        self.output += if v { "1" } else { "0" };
+        Ok(())
+    }
+
+    fn serialize_i8(self, v: i8) -> Result<Self::Ok> {
+        self.serialize_i128(i128::from(v))
+    }
+
+    fn serialize_i16(self, v: i16) -> Result<Self::Ok> {
+        self.serialize_i128(i128::from(v))
+    }
+
+    fn serialize_i32(self, v: i32) -> Result<Self::Ok> {
+        self.serialize_i128(i128::from(v))
+    }
+
+    fn serialize_i64(self, v: i64) -> Result<Self::Ok> {
+        self.serialize_i128(i128::from(v))
+    }
+
+    fn serialize_i128(self, v: i128) -> Result<Self::Ok> {
+        self.output += &v.to_string();
+        Ok(())
+    }
+
+    fn serialize_u8(self, v: u8) -> Result<Self::Ok> {
+        self.serialize_u128(u128::from(v))
+    }
+
+    fn serialize_u16(self, v: u16) -> Result<Self::Ok> {
+        self.serialize_u128(u128::from(v))
+    }
+
+    fn serialize_u32(self, v: u32) -> Result<Self::Ok> {
+        self.serialize_u128(u128::from(v))
+    }
+
+    fn serialize_u64(self, v: u64) -> Result<Self::Ok> {
+        self.serialize_u128(u128::from(v))
+    }
+
+    fn serialize_u128(self, v: u128) -> Result<Self::Ok> {
+        self.output += &v.to_string();
+        Ok(())
+    }
+
+    fn serialize_f32(self, v: f32) -> Result<Self::Ok> {
+        self.serialize_f64(f64::from(v))
+    }
+
+    fn serialize_f64(self, v: f64) -> Result<Self::Ok> {
+        self.output += &v.to_string();
+        Ok(())
+    }
+
+    fn serialize_char(self, v: char) -> Result<Self::Ok> {
+        self.serialize_str(&v.to_string())
+    }
+
+    fn serialize_str(self, v: &str) -> Result<Self::Ok> {
+        self.output += v;
+        Ok(())
+    }
+
+    fn serialize_bytes(self, v: &[u8]) -> Result<Self::Ok> {
+        inner_to_string(&v).unwrap().serialize(self)
+    }
+
+    fn serialize_none(self) -> Result<Self::Ok> {
+        self.serialize_unit()
+    }
+
+    fn serialize_some<T>(self, value: &T) -> Result<Self::Ok>
+    where
+        T: ?Sized + Serialize,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_unit(self) -> Result<Self::Ok> {
+        self.output += "null";
+        Ok(())
+    }
+
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok> {
+        self.serialize_unit()
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+    ) -> Result<Self::Ok> {
+        self.serialize_str(variant)
+    }
+
+    fn serialize_newtype_struct<T>(self, _name: &'static str, value: &T) -> Result<Self::Ok>
+    where
+        T: ?Sized + Serialize,
+    {
+        inner_to_string(&value).unwrap().serialize(self)
+    }
+
+    fn serialize_newtype_variant<T>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _value: &T,
+    ) -> Result<Self::Ok>
+    where
+        T: ?Sized + Serialize,
+    {
+        Err(Error::Unsupported("new Type".into()))
+    }
+
+    fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq> {
+        Err(Error::Unsupported("Seq".into()))
+    }
+
+    fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple> {
+        Err(Error::Unsupported("Tuple".into()))
+    }
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleStruct> {
+        Err(Error::Unsupported("Tuple Struct".into()))
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleVariant> {
+        Err(Error::Unsupported("Tuple Variant".into()))
+    }
+
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap> {
+        Ok(self)
+    }
+
+    fn serialize_struct(self, _name: &'static str, len: usize) -> Result<Self::SerializeStruct> {
+        self.serialize_map(Some(len))
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant> {
+        Err(Error::Unsupported("Struct Variant".into()))
+    }
+}
+
+impl<'a> ser::SerializeMap for &'a mut Serializer {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_key<T>(&mut self, key: &T) -> Result<Self::Ok>
+    where
+        T: ?Sized + Serialize,
+    {
+        if !self.output.is_empty() {
+            self.output += "&";
+        }
+        key.serialize(&mut **self)
+    }
+    fn serialize_value<T>(&mut self, value: &T) -> Result<Self::Ok>
+    where
+        T: ?Sized + Serialize,
+    {
+        self.output += "=";
+        inner_to_string(&value).unwrap().serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<Self::Ok> {
+        Ok(())
+    }
+}
+
+impl<'a> ser::SerializeStruct for &'a mut Serializer {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<Self::Ok>
+    where
+        T: ?Sized + Serialize,
+    {
+        if !self.output.is_empty() {
+            self.output += "&";
+        }
+        key.serialize(&mut **self)?;
+        self.output += "=";
+        inner_to_string(&value).unwrap().serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<Self::Ok> {
+        Ok(())
+    }
+}

--- a/proxmox-api-encode/src/test.rs
+++ b/proxmox-api-encode/src/test.rs
@@ -84,7 +84,7 @@ fn test_struct_inners() {
     println!("re: {}", re);
 }
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 
 use serde_derive::{Deserialize, Serialize};
 
@@ -124,6 +124,108 @@ fn test_serialise() {
     t1.map.insert("flattenmap1".into(), "mvalue1".into());
     let s = to_string(&t1);
     println!("t1: {}", s.unwrap())
+}
+
+#[test]
+fn test_serialize_option() {
+    #[derive(Serialize, Deserialize, Debug)]
+    #[allow(dead_code)]
+    struct Test1 {
+        pub opt: Option<i32>,
+        pub opt2: Option<i32>,
+        pub opt3: Option<i32>,
+        pub opt4: Option<i32>,
+    }
+
+    let s: Test1 = Test1 {
+        opt: Some(1),
+        opt2: None,
+        opt3: Some(3),
+        opt4: None,
+    };
+    let s = to_string(&s);
+    println!("{:?}", s);
+}
+
+#[test]
+fn test_serialize_option_map() {
+    let mut map: HashMap<String, Option<i32>> = HashMap::new();
+
+    map.insert("k".into(), Some(1));
+    map.insert("k2".into(), None);
+    let s = to_string(&map);
+    println!("{:?}", s);
+}
+
+#[test]
+fn test_serialize_nested_option() {
+    #[derive(Serialize, Deserialize, Debug)]
+    #[allow(dead_code)]
+    struct Test1 {
+        pub t: Test2,
+    }
+    #[derive(Serialize, Deserialize, Debug)]
+    struct Test2 {
+        pub opt: Option<i32>,
+        pub opt2: Option<i32>,
+        pub opt3: Option<i32>,
+        pub opt4: Option<i32>,
+    }
+
+    let s: Test1 = Test1 {
+        t: Test2 {
+            opt: Some(1),
+            opt2: None,
+            opt3: Some(3),
+            opt4: None,
+        },
+    };
+    let s = to_string(&s);
+    println!("{:?}", s);
+}
+
+#[test]
+fn test_serialize_nested_option_map() {
+    let mut map: HashMap<String, HashMap<String, Option<i32>>> = HashMap::new();
+    let mut map2 = HashMap::new();
+    map2.insert("inner-key".into(), Some(1));
+    map2.insert("innerkey".into(), None);
+    map.insert("k".into(), map2);
+    let s = to_string(&map);
+    println!("{:?}", s);
+}
+
+#[test]
+fn test_serialize_percent_encode() {
+    #[derive(Serialize, Deserialize, Debug)]
+    struct T {
+        file: String,
+        media: String,
+    }
+    let mut map: HashMap<String, T> = HashMap::new();
+    map.insert(
+        "ide2".into(),
+        T {
+            file: "local:iso/ubuntu-24.img".into(),
+            media: "cdrom".into(),
+        },
+    );
+    let s = to_string(&map);
+    println!("{:?}", s);
+}
+
+#[test]
+fn test_deserialize_percent_encode() {
+    #[derive(Serialize, Deserialize, Debug)]
+    struct T {
+        #[serde(alias = "")]
+        file: String,
+        media: String,
+    }
+    let s = "ide2=local%3Aiso%2Fubuntu-24.img%2Cmedia%3Dcdrom";
+    let map: HashMap<String, T> = from_str(&s).unwrap();
+
+    println!("{:?}", map);
 }
 
 #[test]
@@ -189,7 +291,7 @@ fn test_deserialize_option_none() {
         pub sub1: SubTest1,
         pub e: EnumTest,
         pub arr: Vec<i32>,
-        pub option: Option<i32>
+        pub option: Option<i32>,
     }
 
     let s = r#"status=1&key1=13232&key2=value2&sub1=key1%3Dsubvalue134%3A32&e=I&arr=1%3B2&WTF=1"#;
@@ -208,7 +310,7 @@ fn test_deserialize_option_some() {
         pub sub1: SubTest1,
         pub e: EnumTest,
         pub arr: Vec<i32>,
-        pub option: Option<i32>
+        pub option: Option<i32>,
     }
 
     let s = r#"status=1&key1=13232&key2=value2&sub1=key1%3Dsubvalue134%3A32&e=I&arr=1%3B2&WTF=1&option=1"#;

--- a/proxmox-api-encode/src/test.rs
+++ b/proxmox-api-encode/src/test.rs
@@ -1,0 +1,161 @@
+use crate::{de::from_str, ser::to_string};
+
+#[test]
+pub fn test() {}
+
+#[test]
+fn test_struct() {
+    use serde_derive::Serialize;
+    #[derive(Serialize)]
+    struct T {
+        pub field1: String,
+        pub filed2: String,
+    }
+    let t = T {
+        field1: String::from("1"),
+        filed2: String::from("2"),
+    };
+
+    let re = to_string(&t).unwrap();
+    println!("re: {}", re);
+}
+
+#[test]
+fn test_struct_inner() {
+    use serde_derive::Serialize;
+    #[derive(Serialize)]
+    struct Inner {
+        pub if1: String,
+        pub if2: String,
+    }
+    #[derive(Serialize)]
+    struct T {
+        pub field1: String,
+        pub filed2: String,
+        #[serde(flatten)]
+        pub inner: Inner,
+    }
+
+    let t = T {
+        field1: String::from("1"),
+        filed2: String::from("2"),
+        inner: Inner {
+            if1: String::from("i1"),
+            if2: String::from("i2"),
+        },
+    };
+
+    let re = to_string(&t).unwrap();
+    println!("re: {}", re);
+}
+
+#[test]
+fn test_struct_inners() {
+    use serde_derive::Serialize;
+    use std::collections::BTreeMap;
+    #[derive(Serialize)]
+    struct Inner {
+        pub if1: String,
+        pub if2: String,
+    }
+    #[derive(Serialize)]
+    struct T {
+        pub field1: String,
+        pub filed2: String,
+        #[serde(flatten)]
+        pub inners: BTreeMap<String, Inner>,
+    }
+
+    let mut inners = BTreeMap::new();
+    inners.insert(
+        "list1".into(),
+        Inner {
+            if1: String::from("i1"),
+            if2: String::from("i2"),
+        },
+    );
+    let t = T {
+        field1: String::from("1"),
+        filed2: String::from("2"),
+        inners,
+    };
+
+    let re = to_string(&t).unwrap();
+    println!("re: {}", re);
+}
+
+use std::collections::BTreeMap;
+
+use serde_derive::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug)]
+struct Test1 {
+    pub status: bool,
+    pub key1: String,
+    pub key2: String,
+    pub sub1: SubTest1,
+    pub seq: Vec<String>,
+    #[serde(flatten)]
+    pub map: BTreeMap<String, String>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct SubTest1 {
+    pub key1: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+enum EnumTest {
+    I,
+    II,
+}
+#[test]
+fn test_serialise() {
+    let mut t1 = Test1 {
+        status: true,
+        key1: "value1".into(),
+        key2: "value2".into(),
+        sub1: SubTest1 {
+            key1: "subvalue1".into(),
+        },
+        seq: Vec::from(["1".into(), "2".into()]),
+        map: BTreeMap::new(),
+    };
+    t1.map.insert("flattenmap1".into(), "mvalue1".into());
+    let s = to_string(&t1);
+    println!("t1: {}", s.unwrap())
+}
+
+#[test]
+fn test_deserialize() {
+    #[derive(Deserialize, Debug)]
+    #[allow(dead_code)]
+    struct Test1 {
+        pub status: bool,
+        pub key1: i16,
+        pub key2: String,
+        pub sub1: SubTest1,
+    }
+
+    let s = r#"status=1&key1=13232&key2=value2&sub1=key1%3Dsubvalue134%3A32"#;
+    let s: Test1 = from_str(s).unwrap();
+    println!("{:?}", s);
+}
+
+#[test]
+fn test_deserialize_enum() {
+    #[derive(Deserialize, Debug)]
+    #[allow(dead_code)]
+    struct Test1 {
+        pub status: bool,
+        pub key1: i16,
+        pub key2: String,
+        pub sub1: SubTest1,
+        pub e: EnumTest,
+        pub arr: Vec<i32>,
+    }
+
+    let s = r#"status=1&key1=13232&key2=value2&sub1=key1%3Dsubvalue134%3A32&e=I&arr=1%3B2"#;
+    let s: Test1 = from_str(s).unwrap();
+    println!("{:?}", s);
+}

--- a/proxmox-api-encode/src/test.rs
+++ b/proxmox-api-encode/src/test.rs
@@ -159,3 +159,59 @@ fn test_deserialize_enum() {
     let s: Test1 = from_str(s).unwrap();
     println!("{:?}", s);
 }
+
+#[test]
+fn test_deserialize_extra() {
+    #[derive(Deserialize, Debug)]
+    #[allow(dead_code)]
+    struct Test1 {
+        pub status: bool,
+        pub key1: i16,
+        pub key2: String,
+        pub sub1: SubTest1,
+        pub e: EnumTest,
+        pub arr: Vec<i32>,
+    }
+
+    let s = r#"status=1&key1=13232&key2=value2&sub1=key1%3Dsubvalue134%3A32&e=I&arr=1%3B2&WTF=1"#;
+    let s: Test1 = from_str(s).unwrap();
+    println!("{:?}", s);
+}
+
+#[test]
+fn test_deserialize_option_none() {
+    #[derive(Deserialize, Debug)]
+    #[allow(dead_code)]
+    struct Test1 {
+        pub status: bool,
+        pub key1: i16,
+        pub key2: String,
+        pub sub1: SubTest1,
+        pub e: EnumTest,
+        pub arr: Vec<i32>,
+        pub option: Option<i32>
+    }
+
+    let s = r#"status=1&key1=13232&key2=value2&sub1=key1%3Dsubvalue134%3A32&e=I&arr=1%3B2&WTF=1"#;
+    let s: Test1 = from_str(s).unwrap();
+    println!("{:?}", s);
+}
+
+#[test]
+fn test_deserialize_option_some() {
+    #[derive(Deserialize, Debug)]
+    #[allow(dead_code)]
+    struct Test1 {
+        pub status: bool,
+        pub key1: i16,
+        pub key2: String,
+        pub sub1: SubTest1,
+        pub e: EnumTest,
+        pub arr: Vec<i32>,
+        pub option: Option<i32>
+    }
+
+    let s = r#"status=1&key1=13232&key2=value2&sub1=key1%3Dsubvalue134%3A32&e=I&arr=1%3B2&WTF=1&option=1"#;
+    let s: Test1 = from_str(s).unwrap();
+    println!("{:?}", s);
+}


### PR DESCRIPTION
**Do not merge this pr yet. Open this pr Just let you know What I am currently working with.**
If you check the `serde_urlencoded` you will find that it doesn't support nest serialization, and if we change the serialize `trait` for data structure, this will brake the json encoding. 
And the proxmox's format is a little strange, 
- Proxmox it doesn't support params like `ide1[meedia]=cdrom&ide1[file]=xxx.img`(the serde_qs will parse nested structure like this), 
- Proxmox think the nested struct will we encode like "ide1=xxx.img%2Cmedia%3Dcdrom", 

And the separator in this nested struct is ',' but not the '&', so the value in the struct is encoded in other type.

So we write a new DataFormat According to [serde](https://serde.rs/data-format.html)'s official document.

And the types like `disk` in params should be write like
```rust
#[serde_as]
#[skip_serializing_none]
#[derive(Serialize)]
struct QemuPostParams{
....
#[serde(flatten)]
/// String: "ide0" | "ide1" ....
pub ide:Option<BTreeMap<String,Disk>>
....
}
```