### PR TITLE
Update `rustls` and enable `ring` feature needed by `UreqClient`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,7 +843,7 @@ dependencies = [
  "parking_lot",
  "pretty_env_logger",
  "reqwest",
- "rustls",
+ "rustls 0.23.16",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -989,6 +989,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eee87ff5d9b36712a58574e12e9f0ea80f915a5b0ac518d322b24a465617925e"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1000,15 +1014,15 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.4.1"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd36cc4259e3e4514335c4a138c6b43171a8d61d8f5c9348f9fc7529416f247"
+checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.3"
+version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3bce581c0dd41bce533ce695a1437fa16a7ab5ac3ccfa99fe1a620a7885eabf"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1350,7 +1364,7 @@ dependencies = [
  "flate2",
  "log",
  "once_cell",
- "rustls",
+ "rustls 0.22.4",
  "rustls-pki-types",
  "rustls-webpki",
  "url",

--- a/proxmox-api/Cargo.toml
+++ b/proxmox-api/Cargo.toml
@@ -75,4 +75,4 @@ parking_lot = { optional = true, version = "0.12.1" }
 reqwest = { optional = true, version = "0.12.1", features = ["blocking", "json"] }
 clap = { optional = true, version = "4.5.3", features = ["derive", "env"] }
 pretty_env_logger = { optional = true, version = "0.5.0" }
-rustls = { optional = true, version = "0.22", default-features = false, features = ["ring"] }
+rustls = { optional = true, version = "0.23.16", default-features = false, features = ["ring"] }

--- a/proxmox-api/Cargo.toml
+++ b/proxmox-api/Cargo.toml
@@ -75,4 +75,4 @@ parking_lot = { optional = true, version = "0.12.1" }
 reqwest = { optional = true, version = "0.12.1", features = ["blocking", "json"] }
 clap = { optional = true, version = "4.5.3", features = ["derive", "env"] }
 pretty_env_logger = { optional = true, version = "0.5.0" }
-rustls = { optional = true, version = "0.22", default-features = false }
+rustls = { optional = true, version = "0.22", default-features = false, features = ["ring"] }


### PR DESCRIPTION
TLDR: Update `rustls` to latest version and enable the `ring` feature on it to fix 2 build errors.

--

Hello :)

Thanks for the good work on this library. I'm a software engineer, but relatively new to Rust, so let me know if I'm missing something.

I'm trying to use this API in a hobby project. I need to use the `UreqClient` instead of the `ReqwestClient` because I'm running w/in Rocket, which causes the `ReqwestClient` to panic when it tries to create a blocking `tokio` runtime.

However, when I try to use the `UreqClient`, I get the following build error:

```
error[E0599]: no function or associated item named `builder` found for struct `ClientConfig` in the current scope
   --> /home/garrettmills/.cargo/git/checkouts/p5x-proxmox-api-979e6aed6768e1f7/7d75408/proxmox-api/src/clients/ureq.rs:200:44
    |
200 |         let config = rustls::ClientConfig::builder()
    |                                            ^^^^^^^ function or associated item not found in `ClientConfig`

For more information about this error, try `rustc --explain E0599`.
error: could not compile `proxmox-api` (lib) due to 1 previous error
```

I traced this down to the `Cargo.toml` in the `proxmox-api` crate not enabling the `ring` feature for `rustls`. After enabling that feature (on my fork), I got a _new_ error:

```
error[E0308]: mismatched types
   --> /home/garrettmills/.cargo/git/checkouts/p5x-proxmox-api-979e6aed6768e1f7/5020441/proxmox-api/src/clients/ureq.rs:206:34
    |
206 |             .tls_config(Arc::new(config))
    |                         -------- ^^^^^^ expected `rustls::client::client_conn::ClientConfig`, found `ClientConfig`
    |                         |
    |                         arguments to this function are incorrect
    |
    = note: `ClientConfig` and `rustls::client::client_conn::ClientConfig` have similar names, but are actually distinct types
```

From my testing, updating `rustls` to the latest version (`0.23.16`) resolves this.