### PR TITLE
Update ureq to 2.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,7 +843,7 @@ dependencies = [
  "parking_lot",
  "pretty_env_logger",
  "reqwest",
- "rustls 0.23.16",
+ "rustls",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -976,24 +976,11 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
-dependencies = [
- "log",
- "ring",
- "rustls-pki-types",
- "rustls-webpki",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rustls"
 version = "0.23.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eee87ff5d9b36712a58574e12e9f0ea80f915a5b0ac518d322b24a465617925e"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -1356,17 +1343,16 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "2.9.7"
+version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d11a831e3c0b56e438a28308e7c810799e3c118417f342d30ecec080105395cd"
+checksum = "b74fc6b57825be3373f7054754755f03ac3a8f5d70015ccad699ba2029956f4a"
 dependencies = [
  "base64",
  "flate2",
  "log",
  "once_cell",
- "rustls 0.22.4",
+ "rustls",
  "rustls-pki-types",
- "rustls-webpki",
  "url",
  "webpki-roots",
 ]

--- a/proxmox-api/Cargo.toml
+++ b/proxmox-api/Cargo.toml
@@ -68,7 +68,7 @@ serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.114"
 
 # CLI deps
-ureq = {  optional = true, version = "2.9.7"}
+ureq = {  optional = true, version = "2.10.1"}
 serde_urlencoded = { optional = true, version = "0.7.1" }
 log = { optional = true, version = "0.4.21" }
 parking_lot = { optional = true, version = "0.12.1" }


### PR DESCRIPTION
Fix an oversight (by me) from #23: should also explicitly update `ureq` to match the new `rustls` version to avoid duplicate versions & missing features.