### PR TITLE
Cleanup code

### DIFF
--- a/generator/src/raw/ty.rs
+++ b/generator/src/raw/ty.rs
@@ -14,40 +14,18 @@ use super::{Format, KnownFormat, Optional, Output};
 
 fn parse_value_to_i128(value: &serde_json::Value) -> Option<i128> {
     match value {
-        serde_json::Value::Number(n) => n.as_i64().map(|v| v as i128),
+        serde_json::Value::Number(n) => n.as_i128(),
         serde_json::Value::String(s) => s.parse::<i128>().ok(),
         _ => None,
     }
 }
 
-fn extract_integer_bounds(ty: &TypeKind, field_name: &str) -> Option<BoundedIntegerDef> {
-    let TypeKind::Integer {
-        minimum,
-        maximum,
-        default,
-    } = ty
-    else {
-        return None;
-    };
-
-    let has_constraints = minimum.is_some() || maximum.is_some() || default.is_some();
-
-    if !has_constraints {
-        return None;
-    }
-
-    let min = minimum.as_ref().and_then(parse_value_to_i128);
-    let max = maximum.as_ref().and_then(parse_value_to_i128);
-    let default = default.as_ref().and_then(parse_value_to_i128);
-
-    let name = crate::name_to_ident(&format!("{}Int", field_name));
-
-    Some(BoundedIntegerDef {
-        name,
-        min,
-        max,
-        default,
-    })
+fn parse_optional_i128<'de, D>(deserializer: D) -> Result<Option<i128>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<serde_json::Value>::deserialize(deserializer)?;
+    Ok(value.as_ref().and_then(parse_value_to_i128))
 }
 
 fn parse_value_to_f64(value: &serde_json::Value) -> Option<f64> {
@@ -58,66 +36,28 @@ fn parse_value_to_f64(value: &serde_json::Value) -> Option<f64> {
     }
 }
 
-fn extract_number_bounds(ty: &TypeKind, field_name: &str) -> Option<BoundedNumberDef> {
-    let TypeKind::Number {
-        minimum,
-        maximum,
-        default,
-    } = ty
-    else {
-        return None;
-    };
-
-    let has_constraints = minimum.is_some() || maximum.is_some() || default.is_some();
-
-    if !has_constraints {
-        return None;
-    }
-
-    let min = minimum.as_ref().and_then(parse_value_to_f64);
-    let max = maximum.as_ref().and_then(parse_value_to_f64);
-    let default = default.as_ref().and_then(parse_value_to_f64);
-
-    let name = crate::name_to_ident(&format!("{}Num", field_name));
-
-    Some(BoundedNumberDef {
-        name,
-        min,
-        max,
-        default,
-    })
+fn parse_optional_f64<'de, D>(deserializer: D) -> Result<Option<f64>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<serde_json::Value>::deserialize(deserializer)?;
+    Ok(value.as_ref().and_then(parse_value_to_f64))
 }
 
-fn extract_string_constraints(ty: &TypeKind, field_name: &str) -> Option<BoundedStringDef> {
-    let TypeKind::String {
-        max_length,
-        min_length,
-        pattern,
-        enum_values: None,
-        default,
-    } = ty
-    else {
-        return None;
-    };
-
-    let has_constraints = pattern.is_some() || min_length.is_some() || max_length.is_some();
-    if !has_constraints {
-        return None;
+fn parse_value_to_bool(value: &serde_json::Value) -> Option<bool> {
+    match value {
+        serde_json::Value::Bool(b) => Some(*b),
+        serde_json::Value::String(s) => s.parse::<bool>().ok(),
+        _ => None,
     }
+}
 
-    let pattern = pattern.as_ref().map(|pattern| pattern.to_string());
-
-    let name = crate::name_to_ident(&format!("{}Str", field_name));
-
-    Some(BoundedStringDef {
-        name,
-        min_length: min_length.map(|min| min as usize),
-        max_length: max_length.map(|max| max as usize),
-        pattern,
-        default_val: default
-            .as_ref()
-            .map(|cow_str: &Cow<'_, str>| String::from(cow_str.clone())),
-    })
+fn parse_optional_bool<'de, D>(deserializer: D) -> Result<Option<bool>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<serde_json::Value>::deserialize(deserializer)?;
+    Ok(value.as_ref().and_then(parse_value_to_bool))
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Default)]
@@ -184,6 +124,9 @@ impl Type<'_> {
         let output_type = if let Some(ty) = self.ty.as_ref() {
             match ty {
                 TypeKind::String {
+                    max_length,
+                    min_length,
+                    pattern,
                     enum_values,
                     default,
                     ..
@@ -212,26 +155,44 @@ impl Type<'_> {
                         };
 
                         TypeDef::new_enum(name, no_derives, enum_values, default, self.doc())
-                    } else if let Some(bounded) = extract_string_constraints(ty, field_name) {
-                        TypeDef::BoundedString(bounded)
-                    } else {
+                    } else if let (None | Some(0), None, None) = (min_length, max_length, pattern) {
                         TypeDef::Primitive(PrimitiveTypeDef::String)
-                    }
-                }
-                TypeKind::Number { .. } => {
-                    if let Some(bounded) = extract_number_bounds(ty, field_name) {
-                        TypeDef::BoundedNumber(bounded)
                     } else {
-                        TypeDef::Primitive(PrimitiveTypeDef::Number)
+                        TypeDef::BoundedString(BoundedStringDef {
+                            name: crate::name_to_ident(&format!("{}Str", field_name)),
+                            min_length: min_length.map(|v| v as usize),
+                            max_length: max_length.map(|v| v as usize),
+                            pattern: pattern.as_ref().map(Cow::to_string),
+                            default_val: default.as_ref().map(Cow::to_string),
+                        })
                     }
                 }
-                TypeKind::Integer { .. } => {
-                    if let Some(bounded) = extract_integer_bounds(ty, field_name) {
-                        TypeDef::BoundedInteger(bounded)
-                    } else {
-                        TypeDef::Primitive(PrimitiveTypeDef::Integer)
-                    }
-                }
+                TypeKind::Number {
+                    minimum,
+                    maximum,
+                    default,
+                } => match (minimum, maximum, default) {
+                    (None, None, None) => TypeDef::Primitive(PrimitiveTypeDef::Number),
+                    _ => TypeDef::BoundedNumber(BoundedNumberDef {
+                        name: crate::name_to_ident(&format!("{}Num", field_name)),
+                        min: *minimum,
+                        max: *maximum,
+                        default: *default,
+                    }),
+                },
+                TypeKind::Integer {
+                    minimum,
+                    maximum,
+                    default,
+                } => match (minimum, maximum, default) {
+                    (None, None, None) => TypeDef::Primitive(PrimitiveTypeDef::Integer),
+                    _ => TypeDef::BoundedInteger(BoundedIntegerDef {
+                        name: crate::name_to_ident(&format!("{}Int", field_name)),
+                        min: *minimum,
+                        max: *maximum,
+                        default: *default,
+                    }),
+                },
                 TypeKind::Boolean { .. } => TypeDef::Primitive(PrimitiveTypeDef::Boolean),
                 TypeKind::Array { items } => {
                     let mut output =
@@ -380,26 +341,56 @@ pub enum TypeKind<'a> {
         default: Option<Cow<'a, str>>,
     },
     Number {
-        #[serde(default, alias = "min", skip_serializing_if = "Option::is_none")]
-        minimum: Option<serde_json::Value>,
-        #[serde(default, alias = "max", skip_serializing_if = "Option::is_none")]
-        maximum: Option<serde_json::Value>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        default: Option<serde_json::Value>,
+        #[serde(
+            deserialize_with = "parse_optional_f64",
+            default,
+            alias = "min",
+            skip_serializing_if = "Option::is_none"
+        )]
+        minimum: Option<f64>,
+        #[serde(
+            deserialize_with = "parse_optional_f64",
+            default,
+            alias = "max",
+            skip_serializing_if = "Option::is_none"
+        )]
+        maximum: Option<f64>,
+        #[serde(
+            deserialize_with = "parse_optional_f64",
+            default,
+            skip_serializing_if = "Option::is_none"
+        )]
+        default: Option<f64>,
     },
     Integer {
         // Is sometimes a string containing a u32
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        minimum: Option<serde_json::Value>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        maximum: Option<serde_json::Value>,
+        #[serde(
+            default,
+            deserialize_with = "parse_optional_i128",
+            skip_serializing_if = "Option::is_none"
+        )]
+        minimum: Option<i128>,
+        #[serde(
+            default,
+            deserialize_with = "parse_optional_i128",
+            skip_serializing_if = "Option::is_none"
+        )]
+        maximum: Option<i128>,
         // Is sometimes a string description
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        default: Option<serde_json::Value>,
+        #[serde(
+            default,
+            deserialize_with = "parse_optional_i128",
+            skip_serializing_if = "Option::is_none"
+        )]
+        default: Option<i128>,
     },
     Boolean {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        default: Option<serde_json::Value>,
+        #[serde(
+            deserialize_with = "parse_optional_bool",
+            default,
+            skip_serializing_if = "Option::is_none"
+        )]
+        default: Option<bool>,
     },
     Array {
         items: Box<Type<'a>>,

--- a/proxmox-api/src/types/bounded_integer.rs
+++ b/proxmox-api/src/types/bounded_integer.rs
@@ -42,7 +42,7 @@ pub trait BoundedInteger {
     }
 }
 
-use serde::{Deserializer, Serializer};
+use serde::{Deserialize, Deserializer, Serializer};
 
 pub fn serialize_bounded_integer<T, S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
 where
@@ -52,77 +52,29 @@ where
     serializer.serialize_i128(value.get())
 }
 
+fn parse_value_to_i128(value: &serde_json::Value) -> Option<i128> {
+    match value {
+        serde_json::Value::Number(n) => n.as_i128(),
+        serde_json::Value::String(s) => s.parse::<i128>().ok(),
+        _ => None,
+    }
+}
+
 pub fn deserialize_bounded_integer<'de, T, D>(deserializer: D) -> Result<T, D::Error>
 where
     D: Deserializer<'de>,
     T: BoundedInteger + TryFrom<i128, Error = BoundedIntegerError>,
 {
-    struct Visitor<T> {
-        _phantom: std::marker::PhantomData<T>,
-    }
-
-    impl<T> Default for Visitor<T> {
-        fn default() -> Self {
-            Self {
-                _phantom: std::marker::PhantomData,
-            }
-        }
-    }
-
-    impl<'de, T> serde::de::Visitor<'de> for Visitor<T>
-    where
-        T: BoundedInteger + TryFrom<i128, Error = BoundedIntegerError>,
-    {
-        type Value = T;
-
-        fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-            write!(f, "{}", T::TYPE_DESCRIPTION)
-        }
-
-        fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E>
-        where
-            E: serde::de::Error,
-        {
-            T::try_from(v).map_err(|e| {
-                E::custom(format!(
-                    "could not parse {} as {} with error type {}",
-                    v,
-                    T::TYPE_DESCRIPTION,
-                    e
-                ))
-            })
-        }
-
-        fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
-        where
-            E: serde::de::Error,
-        {
-            self.visit_i128(v as i128)
-        }
-
-        fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
-        where
-            E: serde::de::Error,
-        {
-            self.visit_i128(v as i128)
-        }
-
-        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-        where
-            E: serde::de::Error,
-        {
-            let v_clone = &v;
-            let parsed: i128 = v.parse().map_err(|e| {
-                E::custom(format!(
-                    "could not parse {} as {} with error type {}",
-                    v_clone,
-                    T::TYPE_DESCRIPTION,
-                    e
-                ))
-            })?;
-            self.visit_i128(parsed)
-        }
-    }
-
-    deserializer.deserialize_any(Visitor::default())
+    let value = Option::<serde_json::Value>::deserialize(deserializer)?;
+    let i128_value = value
+        .as_ref()
+        .and_then(parse_value_to_i128)
+        .ok_or_else(|| serde::de::Error::custom("could not parse value as i128"))?;
+    T::try_from(i128_value).map_err(|e| {
+        serde::de::Error::custom(format!(
+            "could not parse as {} with error: {}",
+            T::TYPE_DESCRIPTION,
+            e
+        ))
+    })
 }

--- a/proxmox-api/src/types/bounded_number.rs
+++ b/proxmox-api/src/types/bounded_number.rs
@@ -47,7 +47,7 @@ pub trait BoundedNumber {
     }
 }
 
-use serde::{Deserializer, Serializer};
+use serde::{Deserialize, Deserializer, Serializer};
 
 pub fn serialize_bounded_number<T, S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
 where
@@ -57,77 +57,29 @@ where
     serializer.serialize_f64(value.get())
 }
 
+fn parse_value_to_f64(value: &serde_json::Value) -> Option<f64> {
+    match value {
+        serde_json::Value::Number(n) => n.as_f64(),
+        serde_json::Value::String(s) => s.parse::<f64>().ok(),
+        _ => None,
+    }
+}
+
 pub fn deserialize_bounded_number<'de, T, D>(deserializer: D) -> Result<T, D::Error>
 where
     D: Deserializer<'de>,
     T: BoundedNumber + TryFrom<f64, Error = BoundedNumberError>,
 {
-    struct Visitor<T> {
-        _phantom: std::marker::PhantomData<T>,
-    }
-
-    impl<T> Default for Visitor<T> {
-        fn default() -> Self {
-            Self {
-                _phantom: std::marker::PhantomData,
-            }
-        }
-    }
-
-    impl<'de, T> serde::de::Visitor<'de> for Visitor<T>
-    where
-        T: BoundedNumber + TryFrom<f64, Error = BoundedNumberError>,
-    {
-        type Value = T;
-
-        fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-            write!(f, "{}", T::TYPE_DESCRIPTION)
-        }
-
-        fn visit_f64<E>(self, v: f64) -> Result<Self::Value, E>
-        where
-            E: serde::de::Error,
-        {
-            T::try_from(v).map_err(|e| {
-                E::custom(format!(
-                    "invalid value {} for {} with error type: {}",
-                    v,
-                    T::TYPE_DESCRIPTION,
-                    e
-                ))
-            })
-        }
-
-        fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
-        where
-            E: serde::de::Error,
-        {
-            self.visit_f64(v as f64)
-        }
-
-        fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
-        where
-            E: serde::de::Error,
-        {
-            self.visit_f64(v as f64)
-        }
-
-        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-        where
-            E: serde::de::Error,
-        {
-            let v_clone = &v;
-            let parsed: f64 = v.parse().map_err(|e| {
-                E::custom(format!(
-                    "could not parse {} as {} with error type {}",
-                    v_clone,
-                    T::TYPE_DESCRIPTION,
-                    e
-                ))
-            })?;
-            self.visit_f64(parsed)
-        }
-    }
-
-    deserializer.deserialize_any(Visitor::default())
+    let value = Option::<serde_json::Value>::deserialize(deserializer)?;
+    let f64_value = value
+        .as_ref()
+        .and_then(parse_value_to_f64)
+        .ok_or_else(|| serde::de::Error::custom("could not parse value as f64"))?;
+    T::try_from(f64_value).map_err(|e| {
+        serde::de::Error::custom(format!(
+            "could not parse as {} with error: {}",
+            T::TYPE_DESCRIPTION,
+            e
+        ))
+    })
 }

--- a/proxmox-api/src/types/bounded_string.rs
+++ b/proxmox-api/src/types/bounded_string.rs
@@ -77,7 +77,7 @@ pub trait BoundedString {
     }
 }
 
-use serde::{Deserializer, Serializer};
+use serde::{Deserialize, Deserializer, Serializer};
 
 pub fn serialize_bounded_string<T, S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
 where
@@ -92,57 +92,12 @@ where
     D: Deserializer<'de>,
     T: BoundedString + TryFrom<String, Error = BoundedStringError>,
 {
-    struct Visitor<T> {
-        _phantom: std::marker::PhantomData<T>,
-    }
-
-    impl<T> Default for Visitor<T> {
-        fn default() -> Self {
-            Self {
-                _phantom: std::marker::PhantomData,
-            }
-        }
-    }
-
-    impl<'de, T> serde::de::Visitor<'de> for Visitor<T>
-    where
-        T: BoundedString + TryFrom<String, Error = BoundedStringError>,
-    {
-        type Value = T;
-
-        fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-            write!(f, "{}", T::TYPE_DESCRIPTION)
-        }
-
-        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-        where
-            E: serde::de::Error,
-        {
-            T::try_from(v.to_string()).map_err(|e| {
-                E::custom(format!(
-                    "Invalid value {} for {} with error type: {}",
-                    v,
-                    T::TYPE_DESCRIPTION,
-                    e
-                ))
-            })
-        }
-
-        fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
-        where
-            E: serde::de::Error,
-        {
-            let v_clone = v.clone();
-            T::try_from(v).map_err(|e| {
-                E::custom(format!(
-                    "Invalid value {} for {} with error type: {}",
-                    v_clone,
-                    T::TYPE_DESCRIPTION,
-                    e
-                ))
-            })
-        }
-    }
-
-    deserializer.deserialize_str(Visitor::default())
+    let value = String::deserialize(deserializer)?;
+    T::try_from(value).map_err(|e| {
+        serde::de::Error::custom(format!(
+            "could not parse as {} with error: {}",
+            T::TYPE_DESCRIPTION,
+            e
+        ))
+    })
 }


### PR DESCRIPTION
instead of saving a serde_json::Value and parsing it later, lets parse it directly into a Option<primitive-type> instead. This allows us to remove helper extractor functions.
