### PR TITLE
Add usage of more primitive types

### DIFF
--- a/generator/src/generator/field_def.rs
+++ b/generator/src/generator/field_def.rs
@@ -127,6 +127,8 @@ impl ToTokens for FieldDef {
                 PrimitiveTypeDef::Number => ser_des("number"),
                 PrimitiveTypeDef::Integer => ser_des("int"),
                 PrimitiveTypeDef::Boolean => ser_des("bool"),
+                PrimitiveTypeDef::UnsignedInteger => ser_des("unsigned_int"),
+                PrimitiveTypeDef::NonZeroUnsignedInteger => ser_des("non_zero_pos_int"),
             }
         } else {
             None

--- a/generator/src/generator/mod.rs
+++ b/generator/src/generator/mod.rs
@@ -296,6 +296,14 @@ impl Generator {
             Some(PrimitiveTypeDef::String) | None => {
                 quote!(self.client.#fn_name(#defer_signature))
             }
+            Some(PrimitiveTypeDef::UnsignedInteger) => {
+                let uint_ty = proxmox_api(quote!(types::UnsignedInteger));
+                quote!(Ok(self.client.#fn_name::<_, #uint_ty>(#defer_signature)?.get()))
+            }
+            Some(PrimitiveTypeDef::NonZeroUnsignedInteger) => {
+                let nzuint_ty = proxmox_api(quote!(types::NonZeroUnsignedInteger));
+                quote!(Ok(self.client.#fn_name::<_, #nzuint_ty>(#defer_signature)?.get()))
+            }
         }
     }
 

--- a/generator/src/generator/type_def.rs
+++ b/generator/src/generator/type_def.rs
@@ -16,6 +16,8 @@ pub enum PrimitiveTypeDef {
     String,
     Number,
     Integer,
+    UnsignedInteger,
+    NonZeroUnsignedInteger,
     Boolean,
 }
 
@@ -26,6 +28,8 @@ impl ToTokens for PrimitiveTypeDef {
             PrimitiveTypeDef::Number => quote!(f64),
             PrimitiveTypeDef::Integer => quote!(i64),
             PrimitiveTypeDef::Boolean => quote!(bool),
+            PrimitiveTypeDef::UnsignedInteger => quote!(u64),
+            PrimitiveTypeDef::NonZeroUnsignedInteger => quote!(std::num::NonZeroU64),
         };
 
         tokens.extend(this_tokens)

--- a/generator/src/raw/ty.rs
+++ b/generator/src/raw/ty.rs
@@ -185,7 +185,13 @@ impl Type<'_> {
                     maximum,
                     default,
                 } => match (minimum, maximum, default) {
-                    (None, None, None) => TypeDef::Primitive(PrimitiveTypeDef::Integer),
+                    (None, None, None | Some(0)) => TypeDef::Primitive(PrimitiveTypeDef::Integer),
+                    (Some(0), None, None | Some(0)) => {
+                        TypeDef::Primitive(PrimitiveTypeDef::UnsignedInteger)
+                    }
+                    (Some(1), None, None | Some(1)) => {
+                        TypeDef::Primitive(PrimitiveTypeDef::NonZeroUnsignedInteger)
+                    }
                     _ => TypeDef::BoundedInteger(BoundedIntegerDef {
                         name: crate::name_to_ident(&format!("{}Int", field_name)),
                         min: *minimum,

--- a/proxmox-api/src/generated/access/users.rs
+++ b/proxmox-api/src/generated/access/users.rs
@@ -71,10 +71,14 @@ pub struct GetOutputItems {
     #[doc = "Enable the account (default). You can set this to '0' to disable the account"]
     #[doc = ""]
     pub enable: Option<bool>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Account expiration date (seconds since epoch). '0' means no expiration date."]
     #[doc = ""]
-    pub expire: Option<ExpireInt>,
+    pub expire: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub firstname: Option<FirstnameStr>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
@@ -176,10 +180,14 @@ pub struct PostParams {
     #[doc = "Enable the account (default). You can set this to '0' to disable the account"]
     #[doc = ""]
     pub enable: Option<bool>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Account expiration date (seconds since epoch). '0' means no expiration date."]
     #[doc = ""]
-    pub expire: Option<ExpireInt>,
+    pub expire: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub firstname: Option<FirstnameStr>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
@@ -219,10 +227,14 @@ impl TokensGetOutputItemsTokensItems {
 pub struct TokensGetOutputItemsTokensItems {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub comment: Option<String>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "API token expiration date (seconds since epoch). '0' means no expiration date."]
     #[doc = ""]
-    pub expire: Option<ExpireInt>,
+    pub expire: Option<u64>,
     #[serde(
         serialize_with = "crate::types::serialize_bool_optional",
         deserialize_with = "crate::types::deserialize_bool_optional"
@@ -240,43 +252,6 @@ pub struct TokensGetOutputItemsTokensItems {
         skip_serializing_if = "::std::collections::HashMap::is_empty"
     )]
     pub additional_properties: ::std::collections::HashMap<String, ::serde_json::Value>,
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct ExpireInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for ExpireInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for ExpireInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for ExpireInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for ExpireInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
 }
 #[derive(Debug, Clone, PartialEq, PartialOrd)]
 pub struct CommentStr {

--- a/proxmox-api/src/generated/access/users/userid.rs
+++ b/proxmox-api/src/generated/access/users/userid.rs
@@ -64,10 +64,14 @@ pub struct GetOutput {
     #[doc = "Enable the account (default). You can set this to '0' to disable the account"]
     #[doc = ""]
     pub enable: Option<bool>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Account expiration date (seconds since epoch). '0' means no expiration date."]
     #[doc = ""]
-    pub expire: Option<ExpireInt>,
+    pub expire: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub firstname: Option<FirstnameStr>,
     #[serde(skip_serializing_if = "::std::vec::Vec::is_empty", default)]
@@ -101,10 +105,14 @@ pub struct PutParams {
     #[doc = "Enable the account (default). You can set this to '0' to disable the account"]
     #[doc = ""]
     pub enable: Option<bool>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Account expiration date (seconds since epoch). '0' means no expiration date."]
     #[doc = ""]
-    pub expire: Option<ExpireInt>,
+    pub expire: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub firstname: Option<FirstnameStr>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
@@ -126,10 +134,14 @@ pub struct PutParams {
 pub struct AdditionalPropertiesGetOutputTokens {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub comment: Option<String>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "API token expiration date (seconds since epoch). '0' means no expiration date."]
     #[doc = ""]
-    pub expire: Option<ExpireInt>,
+    pub expire: Option<u64>,
     #[serde(
         serialize_with = "crate::types::serialize_bool_optional",
         deserialize_with = "crate::types::deserialize_bool_optional"
@@ -154,43 +166,6 @@ pub struct TokensGetOutputTokens {
     )]
     pub additional_properties:
         ::std::collections::HashMap<String, AdditionalPropertiesGetOutputTokens>,
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct ExpireInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for ExpireInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for ExpireInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for ExpireInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for ExpireInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
 }
 #[derive(Debug, Clone, PartialEq, PartialOrd)]
 pub struct CommentStr {

--- a/proxmox-api/src/generated/access/users/userid/token.rs
+++ b/proxmox-api/src/generated/access/users/userid/token.rs
@@ -41,10 +41,14 @@ impl GetOutputItems {
 pub struct GetOutputItems {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub comment: Option<String>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "API token expiration date (seconds since epoch). '0' means no expiration date."]
     #[doc = ""]
-    pub expire: Option<ExpireInt>,
+    pub expire: Option<u64>,
     #[serde(
         serialize_with = "crate::types::serialize_bool_optional",
         deserialize_with = "crate::types::deserialize_bool_optional"
@@ -62,43 +66,6 @@ pub struct GetOutputItems {
         skip_serializing_if = "::std::collections::HashMap::is_empty"
     )]
     pub additional_properties: ::std::collections::HashMap<String, ::serde_json::Value>,
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct ExpireInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for ExpireInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for ExpireInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for ExpireInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for ExpireInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
 }
 #[derive(Debug, Clone, PartialEq, PartialOrd)]
 pub struct TokenidStr {

--- a/proxmox-api/src/generated/access/users/userid/token/tokenid.rs
+++ b/proxmox-api/src/generated/access/users/userid/token/tokenid.rs
@@ -62,10 +62,14 @@ where
 pub struct GetOutput {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub comment: Option<String>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "API token expiration date (seconds since epoch). '0' means no expiration date."]
     #[doc = ""]
-    pub expire: Option<ExpireInt>,
+    pub expire: Option<u64>,
     #[serde(
         serialize_with = "crate::types::serialize_bool_optional",
         deserialize_with = "crate::types::deserialize_bool_optional"
@@ -85,10 +89,14 @@ pub struct GetOutput {
 pub struct InfoPostOutputInfo {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub comment: Option<String>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "API token expiration date (seconds since epoch). '0' means no expiration date."]
     #[doc = ""]
-    pub expire: Option<ExpireInt>,
+    pub expire: Option<u64>,
     #[serde(
         serialize_with = "crate::types::serialize_bool_optional",
         deserialize_with = "crate::types::deserialize_bool_optional"
@@ -128,10 +136,14 @@ pub struct PostOutput {
 pub struct PostParams {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub comment: Option<String>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "API token expiration date (seconds since epoch). '0' means no expiration date."]
     #[doc = ""]
-    pub expire: Option<ExpireInt>,
+    pub expire: Option<u64>,
     #[serde(
         serialize_with = "crate::types::serialize_bool_optional",
         deserialize_with = "crate::types::deserialize_bool_optional"
@@ -151,10 +163,14 @@ pub struct PostParams {
 pub struct PutOutput {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub comment: Option<String>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "API token expiration date (seconds since epoch). '0' means no expiration date."]
     #[doc = ""]
-    pub expire: Option<ExpireInt>,
+    pub expire: Option<u64>,
     #[serde(
         serialize_with = "crate::types::serialize_bool_optional",
         deserialize_with = "crate::types::deserialize_bool_optional"
@@ -174,10 +190,14 @@ pub struct PutOutput {
 pub struct PutParams {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub comment: Option<String>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "API token expiration date (seconds since epoch). '0' means no expiration date."]
     #[doc = ""]
-    pub expire: Option<ExpireInt>,
+    pub expire: Option<u64>,
     #[serde(
         serialize_with = "crate::types::serialize_bool_optional",
         deserialize_with = "crate::types::deserialize_bool_optional"
@@ -192,41 +212,4 @@ pub struct PutParams {
         skip_serializing_if = "::std::collections::HashMap::is_empty"
     )]
     pub additional_properties: ::std::collections::HashMap<String, ::serde_json::Value>,
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct ExpireInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for ExpireInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for ExpireInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for ExpireInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for ExpireInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
 }

--- a/proxmox-api/src/generated/cluster/backup.rs
+++ b/proxmox-api/src/generated/cluster/backup.rs
@@ -67,10 +67,14 @@ pub struct PostParams {
     #[doc = "Backup all known guest systems on this host."]
     #[doc = ""]
     pub all: Option<bool>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Limit I/O bandwidth (in KiB/s)."]
     #[doc = ""]
-    pub bwlimit: Option<BwlimitInt>,
+    pub bwlimit: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Description for the Job."]
     #[doc = ""]
@@ -128,10 +132,14 @@ pub struct PostParams {
     #[doc = "Deprecated: Use notification targets/matchers instead. Comma-separated list of email addresses or users that should receive email notifications."]
     #[doc = ""]
     pub mailto: Option<String>,
+    #[serde(
+        serialize_with = "crate::types::serialize_non_zero_pos_int_optional",
+        deserialize_with = "crate::types::deserialize_non_zero_pos_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Deprecated: use 'prune-backups' instead. Maximal number of backup files per guest system."]
     #[doc = ""]
-    pub maxfiles: Option<MaxfilesInt>,
+    pub maxfiles: Option<std::num::NonZeroU64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Backup mode."]
     #[doc = ""]
@@ -164,10 +172,14 @@ pub struct PostParams {
     #[doc = "Other performance-related settings."]
     #[doc = ""]
     pub performance: Option<String>,
+    #[serde(
+        serialize_with = "crate::types::serialize_int_optional",
+        deserialize_with = "crate::types::deserialize_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Use pigz instead of gzip when N\\\\>0. N=1 uses half of cores, N\\\\>1 uses N as thread count."]
     #[doc = ""]
-    pub pigz: Option<PigzInt>,
+    pub pigz: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Backup all known guest systems included in the specified pool."]
     #[doc = ""]
@@ -384,43 +396,6 @@ impl TryFrom<&str> for NotificationPolicy {
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct BwlimitInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for BwlimitInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = Some(0i128);
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for BwlimitInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for BwlimitInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for BwlimitInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
 pub struct IoniceInt(i128);
 impl crate::types::bounded_integer::BoundedInteger for IoniceInt {
     const MIN: Option<i128> = Some(0i128);
@@ -487,80 +462,6 @@ impl ::serde::Serialize for LockwaitInt {
     }
 }
 impl<'de> ::serde::Deserialize<'de> for LockwaitInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct MaxfilesInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for MaxfilesInt {
-    const MIN: Option<i128> = Some(1i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 1";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for MaxfilesInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for MaxfilesInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for MaxfilesInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct PigzInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for PigzInt {
-    const MIN: Option<i128> = None::<i128>;
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = Some(0i128);
-    const TYPE_DESCRIPTION: &'static str = "a valid integer";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for PigzInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for PigzInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for PigzInt {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: ::serde::Deserializer<'de>,

--- a/proxmox-api/src/generated/cluster/backup/id.rs
+++ b/proxmox-api/src/generated/cluster/backup/id.rs
@@ -67,10 +67,14 @@ pub struct PutParams {
     #[doc = "Backup all known guest systems on this host."]
     #[doc = ""]
     pub all: Option<bool>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Limit I/O bandwidth (in KiB/s)."]
     #[doc = ""]
-    pub bwlimit: Option<BwlimitInt>,
+    pub bwlimit: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Description for the Job."]
     #[doc = ""]
@@ -128,10 +132,14 @@ pub struct PutParams {
     #[doc = "Deprecated: Use notification targets/matchers instead. Comma-separated list of email addresses or users that should receive email notifications."]
     #[doc = ""]
     pub mailto: Option<String>,
+    #[serde(
+        serialize_with = "crate::types::serialize_non_zero_pos_int_optional",
+        deserialize_with = "crate::types::deserialize_non_zero_pos_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Deprecated: use 'prune-backups' instead. Maximal number of backup files per guest system."]
     #[doc = ""]
-    pub maxfiles: Option<MaxfilesInt>,
+    pub maxfiles: Option<std::num::NonZeroU64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Backup mode."]
     #[doc = ""]
@@ -164,10 +172,14 @@ pub struct PutParams {
     #[doc = "Other performance-related settings."]
     #[doc = ""]
     pub performance: Option<String>,
+    #[serde(
+        serialize_with = "crate::types::serialize_int_optional",
+        deserialize_with = "crate::types::deserialize_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Use pigz instead of gzip when N\\\\>0. N=1 uses half of cores, N\\\\>1 uses N as thread count."]
     #[doc = ""]
-    pub pigz: Option<PigzInt>,
+    pub pigz: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Backup all known guest systems included in the specified pool."]
     #[doc = ""]
@@ -384,43 +396,6 @@ impl TryFrom<&str> for NotificationPolicy {
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct BwlimitInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for BwlimitInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = Some(0i128);
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for BwlimitInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for BwlimitInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for BwlimitInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
 pub struct IoniceInt(i128);
 impl crate::types::bounded_integer::BoundedInteger for IoniceInt {
     const MIN: Option<i128> = Some(0i128);
@@ -487,80 +462,6 @@ impl ::serde::Serialize for LockwaitInt {
     }
 }
 impl<'de> ::serde::Deserialize<'de> for LockwaitInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct MaxfilesInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for MaxfilesInt {
-    const MIN: Option<i128> = Some(1i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 1";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for MaxfilesInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for MaxfilesInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for MaxfilesInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct PigzInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for PigzInt {
-    const MIN: Option<i128> = None::<i128>;
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = Some(0i128);
-    const TYPE_DESCRIPTION: &'static str = "a valid integer";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for PigzInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for PigzInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for PigzInt {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: ::serde::Deserializer<'de>,

--- a/proxmox-api/src/generated/cluster/config.rs
+++ b/proxmox-api/src/generated/cluster/config.rs
@@ -76,14 +76,22 @@ pub struct PostParams {
     #[doc = "Address and priority information of a single corosync link. (up to 8 links supported; link0..link7)"]
     #[doc = ""]
     pub links: ::std::collections::HashMap<u32, String>,
+    #[serde(
+        serialize_with = "crate::types::serialize_non_zero_pos_int_optional",
+        deserialize_with = "crate::types::deserialize_non_zero_pos_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Node id for this node."]
     #[doc = ""]
-    pub nodeid: Option<NodeidInt>,
+    pub nodeid: Option<std::num::NonZeroU64>,
+    #[serde(
+        serialize_with = "crate::types::serialize_non_zero_pos_int_optional",
+        deserialize_with = "crate::types::deserialize_non_zero_pos_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Number of votes for this node."]
     #[doc = ""]
-    pub votes: Option<VotesInt>,
+    pub votes: Option<std::num::NonZeroU64>,
     #[serde(
         flatten,
         deserialize_with = "crate::types::multi::deserialize_additional_data::<'_, PostParams, _, _>"
@@ -107,80 +115,6 @@ struct NumberedLinks;
 impl crate::types::multi::NumberedItems for NumberedLinks {
     type Item = String;
     const PREFIX: &'static str = "link";
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct NodeidInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for NodeidInt {
-    const MIN: Option<i128> = Some(1i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 1";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for NodeidInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for NodeidInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for NodeidInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct VotesInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for VotesInt {
-    const MIN: Option<i128> = Some(1i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 1";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for VotesInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for VotesInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for VotesInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
 }
 #[derive(Debug, Clone, PartialEq, PartialOrd)]
 pub struct ClusternameStr {

--- a/proxmox-api/src/generated/cluster/config/apiversion.rs
+++ b/proxmox-api/src/generated/cluster/config/apiversion.rs
@@ -20,45 +20,11 @@ where
 {
     #[doc = "Return the version of the cluster join API available on this node."]
     #[doc = ""]
-    pub fn get(&self) -> Result<Int, T::Error> {
+    pub fn get(&self) -> Result<u64, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &())
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct Int(i128);
-impl crate::types::bounded_integer::BoundedInteger for Int {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for Int {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for Int {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for Int {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
+        Ok(self
+            .client
+            .get::<_, crate::types::UnsignedInteger>(&path, &())?
+            .get())
     }
 }

--- a/proxmox-api/src/generated/cluster/config/join.rs
+++ b/proxmox-api/src/generated/cluster/config/join.rs
@@ -79,7 +79,7 @@ impl NodelistGetOutputNodelistItems {
         name: String,
         pve_addr: ::std::net::IpAddr,
         pve_fp: PveFpStr,
-        quorum_votes: QuorumVotesInt,
+        quorum_votes: u64,
     ) -> Self {
         Self {
             name,
@@ -97,15 +97,23 @@ pub struct NodelistGetOutputNodelistItems {
     #[doc = "The cluster node name."]
     #[doc = ""]
     pub name: String,
+    #[serde(
+        serialize_with = "crate::types::serialize_non_zero_pos_int_optional",
+        deserialize_with = "crate::types::deserialize_non_zero_pos_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Node id for this node."]
     #[doc = ""]
-    pub nodeid: Option<NodeidInt>,
+    pub nodeid: Option<std::num::NonZeroU64>,
     pub pve_addr: ::std::net::IpAddr,
     #[doc = "Certificate SHA 256 fingerprint."]
     #[doc = ""]
     pub pve_fp: PveFpStr,
-    pub quorum_votes: QuorumVotesInt,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int",
+        deserialize_with = "crate::types::deserialize_unsigned_int"
+    )]
+    pub quorum_votes: u64,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Address and priority information of a single corosync link. (up to 8 links supported; link0..link7)"]
     #[doc = ""]
@@ -157,17 +165,25 @@ pub struct PostParams {
     #[doc = "Address and priority information of a single corosync link. (up to 8 links supported; link0..link7)"]
     #[doc = ""]
     pub links: ::std::collections::HashMap<u32, String>,
+    #[serde(
+        serialize_with = "crate::types::serialize_non_zero_pos_int_optional",
+        deserialize_with = "crate::types::deserialize_non_zero_pos_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Node id for this node."]
     #[doc = ""]
-    pub nodeid: Option<NodeidInt>,
+    pub nodeid: Option<std::num::NonZeroU64>,
     #[doc = "Superuser (root) password of peer node."]
     #[doc = ""]
     pub password: PasswordStr,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Number of votes for this node"]
     #[doc = ""]
-    pub votes: Option<VotesInt>,
+    pub votes: Option<u64>,
     #[serde(
         flatten,
         deserialize_with = "crate::types::multi::deserialize_additional_data::<'_, PostParams, _, _>"
@@ -200,117 +216,6 @@ struct NumberedLinks;
 impl crate::types::multi::NumberedItems for NumberedLinks {
     type Item = String;
     const PREFIX: &'static str = "link";
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct NodeidInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for NodeidInt {
-    const MIN: Option<i128> = Some(1i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 1";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for NodeidInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for NodeidInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for NodeidInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct QuorumVotesInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for QuorumVotesInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for QuorumVotesInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for QuorumVotesInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for QuorumVotesInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct VotesInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for VotesInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for VotesInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for VotesInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for VotesInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
 }
 #[derive(Debug, Clone, PartialEq, PartialOrd)]
 pub struct FingerprintStr {

--- a/proxmox-api/src/generated/cluster/config/nodes/node.rs
+++ b/proxmox-api/src/generated/cluster/config/nodes/node.rs
@@ -91,14 +91,22 @@ pub struct PostParams {
     #[doc = "IP Address of node to add. Used as fallback if no links are given."]
     #[doc = ""]
     pub new_node_ip: Option<::std::net::IpAddr>,
+    #[serde(
+        serialize_with = "crate::types::serialize_non_zero_pos_int_optional",
+        deserialize_with = "crate::types::deserialize_non_zero_pos_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Node id for this node."]
     #[doc = ""]
-    pub nodeid: Option<NodeidInt>,
+    pub nodeid: Option<std::num::NonZeroU64>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Number of votes for this node"]
     #[doc = ""]
-    pub votes: Option<VotesInt>,
+    pub votes: Option<u64>,
     #[serde(
         flatten,
         deserialize_with = "crate::types::multi::deserialize_additional_data::<'_, PostParams, _, _>"
@@ -122,78 +130,4 @@ struct NumberedLinks;
 impl crate::types::multi::NumberedItems for NumberedLinks {
     type Item = String;
     const PREFIX: &'static str = "link";
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct NodeidInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for NodeidInt {
-    const MIN: Option<i128> = Some(1i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 1";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for NodeidInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for NodeidInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for NodeidInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct VotesInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for VotesInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for VotesInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for VotesInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for VotesInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
 }

--- a/proxmox-api/src/generated/cluster/firewall/groups/group.rs
+++ b/proxmox-api/src/generated/cluster/firewall/groups/group.rs
@@ -113,10 +113,14 @@ pub struct PostParams {
     #[doc = "Restrict TCP/UDP destination port. You can use service names or simple numbers (0-65535), as defined in '/etc/services'. Port ranges can be specified with '\\d+:\\d+', for example '80:85', and you can use comma separated list to match several ports or ranges."]
     #[doc = ""]
     pub dport: Option<String>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Flag to enable/disable a rule."]
     #[doc = ""]
-    pub enable: Option<EnableInt>,
+    pub enable: Option<u64>,
     #[serde(rename = "icmp-type")]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Specify icmp-type. Only valid if proto equals 'icmp' or 'icmpv6'/'ipv6-icmp'."]
@@ -135,10 +139,14 @@ pub struct PostParams {
     #[doc = "Use predefined standard macro."]
     #[doc = ""]
     pub macro_def: Option<MacroStr>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Update rule at position \\\\<pos\\\\>."]
     #[doc = ""]
-    pub pos: Option<PosInt>,
+    pub pos: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "IP protocol. You can use protocol names ('tcp'/'udp') or simple numbers, as defined in '/etc/protocols'."]
     #[doc = ""]
@@ -222,80 +230,6 @@ impl TryFrom<&str> for Type {
             "out" => Ok(Self::Out),
             v => Err(format!("Unknown variant {v}")),
         }
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct EnableInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for EnableInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for EnableInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for EnableInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for EnableInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct PosInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for PosInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for PosInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for PosInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for PosInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
     }
 }
 #[derive(Debug, Clone, PartialEq, PartialOrd)]

--- a/proxmox-api/src/generated/cluster/firewall/groups/group/pos.rs
+++ b/proxmox-api/src/generated/cluster/firewall/groups/group/pos.rs
@@ -161,10 +161,14 @@ pub struct PutParams {
     #[doc = "Restrict TCP/UDP destination port. You can use service names or simple numbers (0-65535), as defined in '/etc/services'. Port ranges can be specified with '\\d+:\\d+', for example '80:85', and you can use comma separated list to match several ports or ranges."]
     #[doc = ""]
     pub dport: Option<String>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Flag to enable/disable a rule."]
     #[doc = ""]
-    pub enable: Option<EnableInt>,
+    pub enable: Option<u64>,
     #[serde(rename = "icmp-type")]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Specify icmp-type. Only valid if proto equals 'icmp' or 'icmpv6'/'ipv6-icmp'."]
@@ -183,10 +187,14 @@ pub struct PutParams {
     #[doc = "Use predefined standard macro."]
     #[doc = ""]
     pub macro_def: Option<MacroStr>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Move rule to new position \\\\<moveto\\\\>. Other arguments are ignored."]
     #[doc = ""]
-    pub moveto: Option<MovetoInt>,
+    pub moveto: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "IP protocol. You can use protocol names ('tcp'/'udp') or simple numbers, as defined in '/etc/protocols'."]
     #[doc = ""]
@@ -271,80 +279,6 @@ impl TryFrom<&str> for Type {
             "out" => Ok(Self::Out),
             v => Err(format!("Unknown variant {v}")),
         }
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct EnableInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for EnableInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for EnableInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for EnableInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for EnableInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct MovetoInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for MovetoInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for MovetoInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for MovetoInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for MovetoInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
     }
 }
 #[derive(Debug, Clone, PartialEq, PartialOrd)]

--- a/proxmox-api/src/generated/cluster/firewall/options.rs
+++ b/proxmox-api/src/generated/cluster/firewall/options.rs
@@ -46,10 +46,14 @@ pub struct GetOutput {
     #[doc = "Enable ebtables rules cluster wide."]
     #[doc = ""]
     pub ebtables: Option<bool>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Enable or disable the firewall cluster wide."]
     #[doc = ""]
-    pub enable: Option<EnableInt>,
+    pub enable: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Log ratelimiting settings"]
     #[doc = ""]
@@ -87,10 +91,14 @@ pub struct PutParams {
     #[doc = "Enable ebtables rules cluster wide."]
     #[doc = ""]
     pub ebtables: Option<bool>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Enable or disable the firewall cluster wide."]
     #[doc = ""]
-    pub enable: Option<EnableInt>,
+    pub enable: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Log ratelimiting settings"]
     #[doc = ""]
@@ -146,43 +154,6 @@ impl TryFrom<&str> for PolicyOut {
             "REJECT" => Ok(Self::REJECT),
             v => Err(format!("Unknown variant {v}")),
         }
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct EnableInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for EnableInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for EnableInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for EnableInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for EnableInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
     }
 }
 #[derive(Debug, Clone, PartialEq, PartialOrd)]

--- a/proxmox-api/src/generated/cluster/firewall/rules.rs
+++ b/proxmox-api/src/generated/cluster/firewall/rules.rs
@@ -102,10 +102,14 @@ pub struct PostParams {
     #[doc = "Restrict TCP/UDP destination port. You can use service names or simple numbers (0-65535), as defined in '/etc/services'. Port ranges can be specified with '\\d+:\\d+', for example '80:85', and you can use comma separated list to match several ports or ranges."]
     #[doc = ""]
     pub dport: Option<String>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Flag to enable/disable a rule."]
     #[doc = ""]
-    pub enable: Option<EnableInt>,
+    pub enable: Option<u64>,
     #[serde(rename = "icmp-type")]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Specify icmp-type. Only valid if proto equals 'icmp' or 'icmpv6'/'ipv6-icmp'."]
@@ -124,10 +128,14 @@ pub struct PostParams {
     #[doc = "Use predefined standard macro."]
     #[doc = ""]
     pub macro_def: Option<MacroStr>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Update rule at position \\\\<pos\\\\>."]
     #[doc = ""]
-    pub pos: Option<PosInt>,
+    pub pos: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "IP protocol. You can use protocol names ('tcp'/'udp') or simple numbers, as defined in '/etc/protocols'."]
     #[doc = ""]
@@ -211,80 +219,6 @@ impl TryFrom<&str> for Type {
             "out" => Ok(Self::Out),
             v => Err(format!("Unknown variant {v}")),
         }
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct EnableInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for EnableInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for EnableInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for EnableInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for EnableInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct PosInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for PosInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for PosInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for PosInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for PosInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
     }
 }
 #[derive(Debug, Clone, PartialEq, PartialOrd)]

--- a/proxmox-api/src/generated/cluster/firewall/rules/pos.rs
+++ b/proxmox-api/src/generated/cluster/firewall/rules/pos.rs
@@ -161,10 +161,14 @@ pub struct PutParams {
     #[doc = "Restrict TCP/UDP destination port. You can use service names or simple numbers (0-65535), as defined in '/etc/services'. Port ranges can be specified with '\\d+:\\d+', for example '80:85', and you can use comma separated list to match several ports or ranges."]
     #[doc = ""]
     pub dport: Option<String>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Flag to enable/disable a rule."]
     #[doc = ""]
-    pub enable: Option<EnableInt>,
+    pub enable: Option<u64>,
     #[serde(rename = "icmp-type")]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Specify icmp-type. Only valid if proto equals 'icmp' or 'icmpv6'/'ipv6-icmp'."]
@@ -183,10 +187,14 @@ pub struct PutParams {
     #[doc = "Use predefined standard macro."]
     #[doc = ""]
     pub macro_def: Option<MacroStr>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Move rule to new position \\\\<moveto\\\\>. Other arguments are ignored."]
     #[doc = ""]
-    pub moveto: Option<MovetoInt>,
+    pub moveto: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "IP protocol. You can use protocol names ('tcp'/'udp') or simple numbers, as defined in '/etc/protocols'."]
     #[doc = ""]
@@ -271,80 +279,6 @@ impl TryFrom<&str> for Type {
             "out" => Ok(Self::Out),
             v => Err(format!("Unknown variant {v}")),
         }
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct EnableInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for EnableInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for EnableInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for EnableInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for EnableInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct MovetoInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for MovetoInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for MovetoInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for MovetoInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for MovetoInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
     }
 }
 #[derive(Debug, Clone, PartialEq, PartialOrd)]

--- a/proxmox-api/src/generated/cluster/log.rs
+++ b/proxmox-api/src/generated/cluster/log.rs
@@ -36,51 +36,18 @@ pub struct GetOutputItems {
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]
 pub struct GetParams {
+    #[serde(
+        serialize_with = "crate::types::serialize_non_zero_pos_int_optional",
+        deserialize_with = "crate::types::deserialize_non_zero_pos_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Maximum number of entries."]
     #[doc = ""]
-    pub max: Option<MaxInt>,
+    pub max: Option<std::num::NonZeroU64>,
     #[serde(
         flatten,
         default,
         skip_serializing_if = "::std::collections::HashMap::is_empty"
     )]
     pub additional_properties: ::std::collections::HashMap<String, ::serde_json::Value>,
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct MaxInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for MaxInt {
-    const MIN: Option<i128> = Some(1i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 1";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for MaxInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for MaxInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for MaxInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
 }

--- a/proxmox-api/src/generated/cluster/options.rs
+++ b/proxmox-api/src/generated/cluster/options.rs
@@ -105,10 +105,14 @@ pub struct PutParams {
     #[doc = "For publicly accessible guests it's recommended that you get your own https://standards.ieee.org/products-programs/regauth/\\\\[OUI from the IEEE\\\\] registered or coordinate with your, or your hosting providers, network admins."]
     #[doc = ""]
     pub mac_prefix: Option<String>,
+    #[serde(
+        serialize_with = "crate::types::serialize_non_zero_pos_int_optional",
+        deserialize_with = "crate::types::deserialize_non_zero_pos_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Defines how many workers (per node) are maximal started  on actions like 'stopall VMs' or task from the ha-manager."]
     #[doc = ""]
-    pub max_workers: Option<MaxWorkersInt>,
+    pub max_workers: Option<std::num::NonZeroU64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "For cluster wide migration settings."]
     #[doc = ""]
@@ -390,43 +394,6 @@ impl TryFrom<&str> for Language {
             "zh_TW" => Ok(Self::ZhTW),
             v => Err(format!("Unknown variant {v}")),
         }
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct MaxWorkersInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for MaxWorkersInt {
-    const MIN: Option<i128> = Some(1i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 1";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for MaxWorkersInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for MaxWorkersInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for MaxWorkersInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
     }
 }
 #[derive(Debug, Clone, PartialEq, PartialOrd)]

--- a/proxmox-api/src/generated/cluster/resources.rs
+++ b/proxmox-api/src/generated/cluster/resources.rs
@@ -71,10 +71,14 @@ pub struct GetOutputItems {
     #[doc = "CPU utilization (when type in node,qemu,lxc)."]
     #[doc = ""]
     pub cpu: Option<CpuNum>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Used disk space in bytes (when type in storage), used root image spave for VMs (type in qemu,lxc)."]
     #[doc = ""]
-    pub disk: Option<DiskInt>,
+    pub disk: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "HA service status (for HA managed VMs)."]
     #[doc = ""]
@@ -90,10 +94,14 @@ pub struct GetOutputItems {
     #[doc = "Number of available CPUs (when type in node,qemu,lxc)."]
     #[doc = ""]
     pub maxcpu: Option<MaxcpuNum>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Storage size in bytes (when type in storage), root image size for VMs (type in qemu,lxc)."]
     #[doc = ""]
-    pub maxdisk: Option<MaxdiskInt>,
+    pub maxdisk: Option<u64>,
     #[serde(
         serialize_with = "crate::types::serialize_int_optional",
         deserialize_with = "crate::types::deserialize_int_optional"
@@ -102,10 +110,14 @@ pub struct GetOutputItems {
     #[doc = "Number of available memory in bytes (when type in node,qemu,lxc)."]
     #[doc = ""]
     pub maxmem: Option<i64>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Used memory in bytes (when type in node,qemu,lxc)."]
     #[doc = ""]
-    pub mem: Option<MemInt>,
+    pub mem: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Name of the resource."]
     #[doc = ""]
@@ -220,117 +232,6 @@ impl TryFrom<&str> for Type2 {
             "storage" => Ok(Self::Storage),
             v => Err(format!("Unknown variant {v}")),
         }
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct DiskInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for DiskInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for DiskInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for DiskInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for DiskInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct MaxdiskInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for MaxdiskInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for MaxdiskInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for MaxdiskInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for MaxdiskInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct MemInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for MemInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for MemInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for MemInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for MemInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]

--- a/proxmox-api/src/generated/cluster/sdn/zones.rs
+++ b/proxmox-api/src/generated/cluster/sdn/zones.rs
@@ -262,10 +262,14 @@ pub struct PostParams {
     #[doc = "Route-Target import"]
     #[doc = ""]
     pub rt_import: Option<String>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Service-VLAN Tag"]
     #[doc = ""]
-    pub tag: Option<TagInt>,
+    pub tag: Option<u64>,
     #[serde(rename = "type")]
     #[doc = "Plugin type."]
     #[doc = ""]
@@ -360,43 +364,6 @@ impl TryFrom<&str> for VlanProtocol {
             "802.1q" => Ok(Self::_8021q),
             v => Err(format!("Unknown variant {v}")),
         }
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct TagInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for TagInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for TagInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for TagInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for TagInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]

--- a/proxmox-api/src/generated/cluster/sdn/zones/zone.rs
+++ b/proxmox-api/src/generated/cluster/sdn/zones/zone.rs
@@ -196,10 +196,14 @@ pub struct PutParams {
     #[doc = "Route-Target import"]
     #[doc = ""]
     pub rt_import: Option<String>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Service-VLAN Tag"]
     #[doc = ""]
-    pub tag: Option<TagInt>,
+    pub tag: Option<u64>,
     #[serde(rename = "vlan-protocol")]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub vlan_protocol: Option<VlanProtocol>,
@@ -256,43 +260,6 @@ impl TryFrom<&str> for VlanProtocol {
             "802.1q" => Ok(Self::_8021q),
             v => Err(format!("Unknown variant {v}")),
         }
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct TagInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for TagInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for TagInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for TagInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for TagInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]

--- a/proxmox-api/src/generated/nodes/node/ceph/log.rs
+++ b/proxmox-api/src/generated/nodes/node/ceph/log.rs
@@ -55,88 +55,22 @@ pub struct GetOutputItems {
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]
 pub struct GetParams {
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub limit: Option<LimitInt>,
+    pub limit: Option<u64>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub start: Option<StartInt>,
+    pub start: Option<u64>,
     #[serde(
         flatten,
         default,
         skip_serializing_if = "::std::collections::HashMap::is_empty"
     )]
     pub additional_properties: ::std::collections::HashMap<String, ::serde_json::Value>,
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct LimitInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for LimitInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for LimitInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for LimitInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for LimitInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct StartInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for StartInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for StartInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for StartInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for StartInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
 }

--- a/proxmox-api/src/generated/nodes/node/ceph/osd.rs
+++ b/proxmox-api/src/generated/nodes/node/ceph/osd.rs
@@ -90,12 +90,16 @@ pub struct PostParams {
     #[doc = ""]
     pub encrypted: Option<bool>,
     #[serde(rename = "osds-per-device")]
+    #[serde(
+        serialize_with = "crate::types::serialize_non_zero_pos_int_optional",
+        deserialize_with = "crate::types::deserialize_non_zero_pos_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "OSD services per physical device. Only useful for fast NVMe devices"]
     #[doc = ""]
     #[doc = ".\" to utilize their performance better."]
     #[doc = ""]
-    pub osds_per_device: Option<OsdsPerDeviceInt>,
+    pub osds_per_device: Option<std::num::NonZeroU64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Block device name for block.wal."]
     #[doc = ""]
@@ -112,43 +116,6 @@ pub struct PostParams {
         skip_serializing_if = "::std::collections::HashMap::is_empty"
     )]
     pub additional_properties: ::std::collections::HashMap<String, ::serde_json::Value>,
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct OsdsPerDeviceInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for OsdsPerDeviceInt {
-    const MIN: Option<i128> = Some(1i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 1";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for OsdsPerDeviceInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for OsdsPerDeviceInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for OsdsPerDeviceInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
 }
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
 pub struct DbDevSizeNum(f64);

--- a/proxmox-api/src/generated/nodes/node/firewall/log.rs
+++ b/proxmox-api/src/generated/nodes/node/firewall/log.rs
@@ -55,170 +55,38 @@ pub struct GetOutputItems {
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]
 pub struct GetParams {
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub limit: Option<LimitInt>,
+    pub limit: Option<u64>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Display log since this UNIX epoch."]
     #[doc = ""]
-    pub since: Option<SinceInt>,
+    pub since: Option<u64>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub start: Option<StartInt>,
+    pub start: Option<u64>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Display log until this UNIX epoch."]
     #[doc = ""]
-    pub until: Option<UntilInt>,
+    pub until: Option<u64>,
     #[serde(
         flatten,
         default,
         skip_serializing_if = "::std::collections::HashMap::is_empty"
     )]
     pub additional_properties: ::std::collections::HashMap<String, ::serde_json::Value>,
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct LimitInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for LimitInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for LimitInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for LimitInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for LimitInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct SinceInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for SinceInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for SinceInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for SinceInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for SinceInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct StartInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for StartInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for StartInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for StartInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for StartInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct UntilInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for UntilInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for UntilInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for UntilInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for UntilInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
 }

--- a/proxmox-api/src/generated/nodes/node/firewall/rules.rs
+++ b/proxmox-api/src/generated/nodes/node/firewall/rules.rs
@@ -102,10 +102,14 @@ pub struct PostParams {
     #[doc = "Restrict TCP/UDP destination port. You can use service names or simple numbers (0-65535), as defined in '/etc/services'. Port ranges can be specified with '\\d+:\\d+', for example '80:85', and you can use comma separated list to match several ports or ranges."]
     #[doc = ""]
     pub dport: Option<String>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Flag to enable/disable a rule."]
     #[doc = ""]
-    pub enable: Option<EnableInt>,
+    pub enable: Option<u64>,
     #[serde(rename = "icmp-type")]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Specify icmp-type. Only valid if proto equals 'icmp' or 'icmpv6'/'ipv6-icmp'."]
@@ -124,10 +128,14 @@ pub struct PostParams {
     #[doc = "Use predefined standard macro."]
     #[doc = ""]
     pub macro_def: Option<MacroStr>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Update rule at position \\\\<pos\\\\>."]
     #[doc = ""]
-    pub pos: Option<PosInt>,
+    pub pos: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "IP protocol. You can use protocol names ('tcp'/'udp') or simple numbers, as defined in '/etc/protocols'."]
     #[doc = ""]
@@ -211,80 +219,6 @@ impl TryFrom<&str> for Type {
             "out" => Ok(Self::Out),
             v => Err(format!("Unknown variant {v}")),
         }
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct EnableInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for EnableInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for EnableInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for EnableInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for EnableInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct PosInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for PosInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for PosInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for PosInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for PosInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
     }
 }
 #[derive(Debug, Clone, PartialEq, PartialOrd)]

--- a/proxmox-api/src/generated/nodes/node/firewall/rules/pos.rs
+++ b/proxmox-api/src/generated/nodes/node/firewall/rules/pos.rs
@@ -161,10 +161,14 @@ pub struct PutParams {
     #[doc = "Restrict TCP/UDP destination port. You can use service names or simple numbers (0-65535), as defined in '/etc/services'. Port ranges can be specified with '\\d+:\\d+', for example '80:85', and you can use comma separated list to match several ports or ranges."]
     #[doc = ""]
     pub dport: Option<String>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Flag to enable/disable a rule."]
     #[doc = ""]
-    pub enable: Option<EnableInt>,
+    pub enable: Option<u64>,
     #[serde(rename = "icmp-type")]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Specify icmp-type. Only valid if proto equals 'icmp' or 'icmpv6'/'ipv6-icmp'."]
@@ -183,10 +187,14 @@ pub struct PutParams {
     #[doc = "Use predefined standard macro."]
     #[doc = ""]
     pub macro_def: Option<MacroStr>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Move rule to new position \\\\<moveto\\\\>. Other arguments are ignored."]
     #[doc = ""]
-    pub moveto: Option<MovetoInt>,
+    pub moveto: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "IP protocol. You can use protocol names ('tcp'/'udp') or simple numbers, as defined in '/etc/protocols'."]
     #[doc = ""]
@@ -271,80 +279,6 @@ impl TryFrom<&str> for Type {
             "out" => Ok(Self::Out),
             v => Err(format!("Unknown variant {v}")),
         }
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct EnableInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for EnableInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for EnableInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for EnableInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for EnableInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct MovetoInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for MovetoInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for MovetoInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for MovetoInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for MovetoInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
     }
 }
 #[derive(Debug, Clone, PartialEq, PartialOrd)]

--- a/proxmox-api/src/generated/nodes/node/journal.rs
+++ b/proxmox-api/src/generated/nodes/node/journal.rs
@@ -31,137 +31,38 @@ pub struct GetParams {
     #[doc = "End before the given Cursor. Conflicts with 'until'"]
     #[doc = ""]
     pub endcursor: Option<String>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Limit to the last X lines. Conflicts with a range."]
     #[doc = ""]
-    pub lastentries: Option<LastentriesInt>,
+    pub lastentries: Option<u64>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Display all log since this UNIX epoch. Conflicts with 'startcursor'."]
     #[doc = ""]
-    pub since: Option<SinceInt>,
+    pub since: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Start after the given Cursor. Conflicts with 'since'"]
     #[doc = ""]
     pub startcursor: Option<String>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Display all log until this UNIX epoch. Conflicts with 'endcursor'."]
     #[doc = ""]
-    pub until: Option<UntilInt>,
+    pub until: Option<u64>,
     #[serde(
         flatten,
         default,
         skip_serializing_if = "::std::collections::HashMap::is_empty"
     )]
     pub additional_properties: ::std::collections::HashMap<String, ::serde_json::Value>,
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct LastentriesInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for LastentriesInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for LastentriesInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for LastentriesInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for LastentriesInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct SinceInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for SinceInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for SinceInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for SinceInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for SinceInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct UntilInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for UntilInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for UntilInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for UntilInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for UntilInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
 }

--- a/proxmox-api/src/generated/nodes/node/lxc/vmid/firewall/log.rs
+++ b/proxmox-api/src/generated/nodes/node/lxc/vmid/firewall/log.rs
@@ -55,170 +55,38 @@ pub struct GetOutputItems {
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]
 pub struct GetParams {
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub limit: Option<LimitInt>,
+    pub limit: Option<u64>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Display log since this UNIX epoch."]
     #[doc = ""]
-    pub since: Option<SinceInt>,
+    pub since: Option<u64>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub start: Option<StartInt>,
+    pub start: Option<u64>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Display log until this UNIX epoch."]
     #[doc = ""]
-    pub until: Option<UntilInt>,
+    pub until: Option<u64>,
     #[serde(
         flatten,
         default,
         skip_serializing_if = "::std::collections::HashMap::is_empty"
     )]
     pub additional_properties: ::std::collections::HashMap<String, ::serde_json::Value>,
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct LimitInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for LimitInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for LimitInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for LimitInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for LimitInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct SinceInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for SinceInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for SinceInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for SinceInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for SinceInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct StartInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for StartInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for StartInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for StartInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for StartInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct UntilInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for UntilInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for UntilInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for UntilInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for UntilInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
 }

--- a/proxmox-api/src/generated/nodes/node/lxc/vmid/firewall/rules.rs
+++ b/proxmox-api/src/generated/nodes/node/lxc/vmid/firewall/rules.rs
@@ -102,10 +102,14 @@ pub struct PostParams {
     #[doc = "Restrict TCP/UDP destination port. You can use service names or simple numbers (0-65535), as defined in '/etc/services'. Port ranges can be specified with '\\d+:\\d+', for example '80:85', and you can use comma separated list to match several ports or ranges."]
     #[doc = ""]
     pub dport: Option<String>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Flag to enable/disable a rule."]
     #[doc = ""]
-    pub enable: Option<EnableInt>,
+    pub enable: Option<u64>,
     #[serde(rename = "icmp-type")]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Specify icmp-type. Only valid if proto equals 'icmp' or 'icmpv6'/'ipv6-icmp'."]
@@ -124,10 +128,14 @@ pub struct PostParams {
     #[doc = "Use predefined standard macro."]
     #[doc = ""]
     pub macro_def: Option<MacroStr>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Update rule at position \\\\<pos\\\\>."]
     #[doc = ""]
-    pub pos: Option<PosInt>,
+    pub pos: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "IP protocol. You can use protocol names ('tcp'/'udp') or simple numbers, as defined in '/etc/protocols'."]
     #[doc = ""]
@@ -211,80 +219,6 @@ impl TryFrom<&str> for Type {
             "out" => Ok(Self::Out),
             v => Err(format!("Unknown variant {v}")),
         }
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct EnableInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for EnableInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for EnableInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for EnableInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for EnableInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct PosInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for PosInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for PosInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for PosInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for PosInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
     }
 }
 #[derive(Debug, Clone, PartialEq, PartialOrd)]

--- a/proxmox-api/src/generated/nodes/node/lxc/vmid/firewall/rules/pos.rs
+++ b/proxmox-api/src/generated/nodes/node/lxc/vmid/firewall/rules/pos.rs
@@ -161,10 +161,14 @@ pub struct PutParams {
     #[doc = "Restrict TCP/UDP destination port. You can use service names or simple numbers (0-65535), as defined in '/etc/services'. Port ranges can be specified with '\\d+:\\d+', for example '80:85', and you can use comma separated list to match several ports or ranges."]
     #[doc = ""]
     pub dport: Option<String>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Flag to enable/disable a rule."]
     #[doc = ""]
-    pub enable: Option<EnableInt>,
+    pub enable: Option<u64>,
     #[serde(rename = "icmp-type")]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Specify icmp-type. Only valid if proto equals 'icmp' or 'icmpv6'/'ipv6-icmp'."]
@@ -183,10 +187,14 @@ pub struct PutParams {
     #[doc = "Use predefined standard macro."]
     #[doc = ""]
     pub macro_def: Option<MacroStr>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Move rule to new position \\\\<moveto\\\\>. Other arguments are ignored."]
     #[doc = ""]
-    pub moveto: Option<MovetoInt>,
+    pub moveto: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "IP protocol. You can use protocol names ('tcp'/'udp') or simple numbers, as defined in '/etc/protocols'."]
     #[doc = ""]
@@ -271,80 +279,6 @@ impl TryFrom<&str> for Type {
             "out" => Ok(Self::Out),
             v => Err(format!("Unknown variant {v}")),
         }
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct EnableInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for EnableInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for EnableInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for EnableInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for EnableInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct MovetoInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for MovetoInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for MovetoInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for MovetoInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for MovetoInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
     }
 }
 #[derive(Debug, Clone, PartialEq, PartialOrd)]

--- a/proxmox-api/src/generated/nodes/node/lxc/vmid/status/reboot.rs
+++ b/proxmox-api/src/generated/nodes/node/lxc/vmid/status/reboot.rs
@@ -27,51 +27,18 @@ where
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]
 pub struct PostParams {
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Wait maximal timeout seconds for the shutdown."]
     #[doc = ""]
-    pub timeout: Option<TimeoutInt>,
+    pub timeout: Option<u64>,
     #[serde(
         flatten,
         default,
         skip_serializing_if = "::std::collections::HashMap::is_empty"
     )]
     pub additional_properties: ::std::collections::HashMap<String, ::serde_json::Value>,
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct TimeoutInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for TimeoutInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for TimeoutInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for TimeoutInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for TimeoutInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
 }

--- a/proxmox-api/src/generated/nodes/node/migrateall.rs
+++ b/proxmox-api/src/generated/nodes/node/migrateall.rs
@@ -38,10 +38,14 @@ impl PostParams {
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize)]
 pub struct PostParams {
+    #[serde(
+        serialize_with = "crate::types::serialize_non_zero_pos_int_optional",
+        deserialize_with = "crate::types::deserialize_non_zero_pos_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Maximal number of parallel migration job. If not set, uses'max_workers' from datacenter.cfg. One of both must be set!"]
     #[doc = ""]
-    pub maxworkers: Option<MaxworkersInt>,
+    pub maxworkers: Option<std::num::NonZeroU64>,
     #[doc = "Target node."]
     #[doc = ""]
     pub target: String,
@@ -64,41 +68,4 @@ pub struct PostParams {
         skip_serializing_if = "::std::collections::HashMap::is_empty"
     )]
     pub additional_properties: ::std::collections::HashMap<String, ::serde_json::Value>,
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct MaxworkersInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for MaxworkersInt {
-    const MIN: Option<i128> = Some(1i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 1";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for MaxworkersInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for MaxworkersInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for MaxworkersInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
 }

--- a/proxmox-api/src/generated/nodes/node/qemu.rs
+++ b/proxmox-api/src/generated/nodes/node/qemu.rs
@@ -296,10 +296,14 @@ pub struct PostParams {
     #[doc = "Automatic restart after crash (currently ignored)."]
     #[doc = ""]
     pub autostart: Option<bool>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Amount of target RAM for the VM in MiB. Using zero disables the ballon driver."]
     #[doc = ""]
-    pub balloon: Option<BalloonInt>,
+    pub balloon: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Select BIOS implementation."]
     #[doc = ""]
@@ -312,10 +316,14 @@ pub struct PostParams {
     #[doc = "Enable booting from specified disk. Deprecated: Use 'boot: order=foo;bar' instead."]
     #[doc = ""]
     pub bootdisk: Option<BootdiskStr>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Override I/O bandwidth limit (in KiB/s)."]
     #[doc = ""]
-    pub bwlimit: Option<BwlimitInt>,
+    pub bwlimit: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "This is an alias for option -ide2"]
     #[doc = ""]
@@ -344,10 +352,14 @@ pub struct PostParams {
     #[doc = "cloud-init: User name to change ssh keys and password for instead of the image's configured default user."]
     #[doc = ""]
     pub ciuser: Option<String>,
+    #[serde(
+        serialize_with = "crate::types::serialize_non_zero_pos_int_optional",
+        deserialize_with = "crate::types::deserialize_non_zero_pos_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "The number of cores per socket."]
     #[doc = ""]
-    pub cores: Option<CoresInt>,
+    pub cores: Option<std::num::NonZeroU64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Emulated CPU type."]
     #[doc = ""]
@@ -511,10 +523,14 @@ pub struct PostParams {
     #[doc = "Set maximum tolerated downtime (in seconds) for migrations."]
     #[doc = ""]
     pub migrate_downtime: Option<MigrateDowntimeNum>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Set maximum speed (in MB/s) for migrations. Value 0 is no limit."]
     #[doc = ""]
-    pub migrate_speed: Option<MigrateSpeedInt>,
+    pub migrate_speed: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Set a name for the VM. Only used on the configuration web interface."]
     #[doc = ""]
@@ -695,14 +711,22 @@ pub struct PostParams {
     #[doc = "Specify SMBIOS type 1 fields."]
     #[doc = ""]
     pub smbios1: Option<Smbios1Str>,
+    #[serde(
+        serialize_with = "crate::types::serialize_non_zero_pos_int_optional",
+        deserialize_with = "crate::types::deserialize_non_zero_pos_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "The number of CPUs. Please use option -sockets instead."]
     #[doc = ""]
-    pub smp: Option<SmpInt>,
+    pub smp: Option<std::num::NonZeroU64>,
+    #[serde(
+        serialize_with = "crate::types::serialize_non_zero_pos_int_optional",
+        deserialize_with = "crate::types::deserialize_non_zero_pos_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "The number of CPU sockets."]
     #[doc = ""]
-    pub sockets: Option<SocketsInt>,
+    pub sockets: Option<std::num::NonZeroU64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Configure additional enhancements for SPICE."]
     #[doc = ""]
@@ -1295,117 +1319,6 @@ impl crate::types::multi::NumberedItems for NumberedVirtios {
     const PREFIX: &'static str = "virtio";
 }
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct BalloonInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for BalloonInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for BalloonInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for BalloonInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for BalloonInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct BwlimitInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for BwlimitInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for BwlimitInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for BwlimitInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for BwlimitInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct CoresInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for CoresInt {
-    const MIN: Option<i128> = Some(1i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = Some(1i128);
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 1";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for CoresInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for CoresInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for CoresInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
 pub struct CpuunitsInt(i128);
 impl crate::types::bounded_integer::BoundedInteger for CpuunitsInt {
     const MIN: Option<i128> = Some(1i128);
@@ -1443,43 +1356,6 @@ impl<'de> ::serde::Deserialize<'de> for CpuunitsInt {
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct MigrateSpeedInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for MigrateSpeedInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = Some(0i128);
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for MigrateSpeedInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for MigrateSpeedInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for MigrateSpeedInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
 pub struct SharesInt(i128);
 impl crate::types::bounded_integer::BoundedInteger for SharesInt {
     const MIN: Option<i128> = Some(0i128);
@@ -1509,80 +1385,6 @@ impl ::serde::Serialize for SharesInt {
     }
 }
 impl<'de> ::serde::Deserialize<'de> for SharesInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct SmpInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for SmpInt {
-    const MIN: Option<i128> = Some(1i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = Some(1i128);
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 1";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for SmpInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for SmpInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for SmpInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct SocketsInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for SocketsInt {
-    const MIN: Option<i128> = Some(1i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = Some(1i128);
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 1";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for SocketsInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for SocketsInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for SocketsInt {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: ::serde::Deserializer<'de>,

--- a/proxmox-api/src/generated/nodes/node/qemu/vmid/clone.rs
+++ b/proxmox-api/src/generated/nodes/node/qemu/vmid/clone.rs
@@ -44,10 +44,14 @@ impl PostParams {
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize)]
 pub struct PostParams {
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Override I/O bandwidth limit (in KiB/s)."]
     #[doc = ""]
-    pub bwlimit: Option<BwlimitInt>,
+    pub bwlimit: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Description for the new VM."]
     #[doc = ""]
@@ -114,43 +118,6 @@ impl TryFrom<&str> for Format {
             "vmdk" => Ok(Self::Vmdk),
             v => Err(format!("Unknown variant {v}")),
         }
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct BwlimitInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for BwlimitInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for BwlimitInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for BwlimitInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for BwlimitInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]

--- a/proxmox-api/src/generated/nodes/node/qemu/vmid/config.rs
+++ b/proxmox-api/src/generated/nodes/node/qemu/vmid/config.rs
@@ -176,10 +176,14 @@ pub struct GetOutput {
     #[doc = "Automatic restart after crash (currently ignored)."]
     #[doc = ""]
     pub autostart: Option<bool>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Amount of target RAM for the VM in MiB. Using zero disables the ballon driver."]
     #[doc = ""]
-    pub balloon: Option<BalloonInt>,
+    pub balloon: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Select BIOS implementation."]
     #[doc = ""]
@@ -220,10 +224,14 @@ pub struct GetOutput {
     #[doc = "cloud-init: User name to change ssh keys and password for instead of the image's configured default user."]
     #[doc = ""]
     pub ciuser: Option<String>,
+    #[serde(
+        serialize_with = "crate::types::serialize_non_zero_pos_int_optional",
+        deserialize_with = "crate::types::deserialize_non_zero_pos_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "The number of cores per socket."]
     #[doc = ""]
-    pub cores: Option<CoresInt>,
+    pub cores: Option<std::num::NonZeroU64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Emulated CPU type."]
     #[doc = ""]
@@ -373,10 +381,14 @@ pub struct GetOutput {
     #[doc = "Set maximum tolerated downtime (in seconds) for migrations."]
     #[doc = ""]
     pub migrate_downtime: Option<MigrateDowntimeNum>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Set maximum speed (in MB/s) for migrations. Value 0 is no limit."]
     #[doc = ""]
-    pub migrate_speed: Option<MigrateSpeedInt>,
+    pub migrate_speed: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Set a name for the VM. Only used on the configuration web interface."]
     #[doc = ""]
@@ -553,14 +565,22 @@ pub struct GetOutput {
     #[doc = "Specify SMBIOS type 1 fields."]
     #[doc = ""]
     pub smbios1: Option<Smbios1Str>,
+    #[serde(
+        serialize_with = "crate::types::serialize_non_zero_pos_int_optional",
+        deserialize_with = "crate::types::deserialize_non_zero_pos_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "The number of CPUs. Please use option -sockets instead."]
     #[doc = ""]
-    pub smp: Option<SmpInt>,
+    pub smp: Option<std::num::NonZeroU64>,
+    #[serde(
+        serialize_with = "crate::types::serialize_non_zero_pos_int_optional",
+        deserialize_with = "crate::types::deserialize_non_zero_pos_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "The number of CPU sockets."]
     #[doc = ""]
-    pub sockets: Option<SocketsInt>,
+    pub sockets: Option<std::num::NonZeroU64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Configure additional enhancements for SPICE."]
     #[doc = ""]
@@ -780,10 +800,14 @@ pub struct PostParams {
     #[doc = "Time to wait for the task to finish. We return 'null' if the task finish within that time."]
     #[doc = ""]
     pub background_delay: Option<BackgroundDelayInt>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Amount of target RAM for the VM in MiB. Using zero disables the ballon driver."]
     #[doc = ""]
-    pub balloon: Option<BalloonInt>,
+    pub balloon: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Select BIOS implementation."]
     #[doc = ""]
@@ -824,10 +848,14 @@ pub struct PostParams {
     #[doc = "cloud-init: User name to change ssh keys and password for instead of the image's configured default user."]
     #[doc = ""]
     pub ciuser: Option<String>,
+    #[serde(
+        serialize_with = "crate::types::serialize_non_zero_pos_int_optional",
+        deserialize_with = "crate::types::deserialize_non_zero_pos_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "The number of cores per socket."]
     #[doc = ""]
-    pub cores: Option<CoresInt>,
+    pub cores: Option<std::num::NonZeroU64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Emulated CPU type."]
     #[doc = ""]
@@ -990,10 +1018,14 @@ pub struct PostParams {
     #[doc = "Set maximum tolerated downtime (in seconds) for migrations."]
     #[doc = ""]
     pub migrate_downtime: Option<MigrateDowntimeNum>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Set maximum speed (in MB/s) for migrations. Value 0 is no limit."]
     #[doc = ""]
-    pub migrate_speed: Option<MigrateSpeedInt>,
+    pub migrate_speed: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Set a name for the VM. Only used on the configuration web interface."]
     #[doc = ""]
@@ -1182,14 +1214,22 @@ pub struct PostParams {
     #[doc = "Specify SMBIOS type 1 fields."]
     #[doc = ""]
     pub smbios1: Option<Smbios1Str>,
+    #[serde(
+        serialize_with = "crate::types::serialize_non_zero_pos_int_optional",
+        deserialize_with = "crate::types::deserialize_non_zero_pos_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "The number of CPUs. Please use option -sockets instead."]
     #[doc = ""]
-    pub smp: Option<SmpInt>,
+    pub smp: Option<std::num::NonZeroU64>,
+    #[serde(
+        serialize_with = "crate::types::serialize_non_zero_pos_int_optional",
+        deserialize_with = "crate::types::deserialize_non_zero_pos_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "The number of CPU sockets."]
     #[doc = ""]
-    pub sockets: Option<SocketsInt>,
+    pub sockets: Option<std::num::NonZeroU64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Configure additional enhancements for SPICE."]
     #[doc = ""]
@@ -1384,10 +1424,14 @@ pub struct PutParams {
     #[doc = "Automatic restart after crash (currently ignored)."]
     #[doc = ""]
     pub autostart: Option<bool>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Amount of target RAM for the VM in MiB. Using zero disables the ballon driver."]
     #[doc = ""]
-    pub balloon: Option<BalloonInt>,
+    pub balloon: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Select BIOS implementation."]
     #[doc = ""]
@@ -1428,10 +1472,14 @@ pub struct PutParams {
     #[doc = "cloud-init: User name to change ssh keys and password for instead of the image's configured default user."]
     #[doc = ""]
     pub ciuser: Option<String>,
+    #[serde(
+        serialize_with = "crate::types::serialize_non_zero_pos_int_optional",
+        deserialize_with = "crate::types::deserialize_non_zero_pos_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "The number of cores per socket."]
     #[doc = ""]
-    pub cores: Option<CoresInt>,
+    pub cores: Option<std::num::NonZeroU64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Emulated CPU type."]
     #[doc = ""]
@@ -1594,10 +1642,14 @@ pub struct PutParams {
     #[doc = "Set maximum tolerated downtime (in seconds) for migrations."]
     #[doc = ""]
     pub migrate_downtime: Option<MigrateDowntimeNum>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Set maximum speed (in MB/s) for migrations. Value 0 is no limit."]
     #[doc = ""]
-    pub migrate_speed: Option<MigrateSpeedInt>,
+    pub migrate_speed: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Set a name for the VM. Only used on the configuration web interface."]
     #[doc = ""]
@@ -1786,14 +1838,22 @@ pub struct PutParams {
     #[doc = "Specify SMBIOS type 1 fields."]
     #[doc = ""]
     pub smbios1: Option<Smbios1Str>,
+    #[serde(
+        serialize_with = "crate::types::serialize_non_zero_pos_int_optional",
+        deserialize_with = "crate::types::deserialize_non_zero_pos_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "The number of CPUs. Please use option -sockets instead."]
     #[doc = ""]
-    pub smp: Option<SmpInt>,
+    pub smp: Option<std::num::NonZeroU64>,
+    #[serde(
+        serialize_with = "crate::types::serialize_non_zero_pos_int_optional",
+        deserialize_with = "crate::types::deserialize_non_zero_pos_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "The number of CPU sockets."]
     #[doc = ""]
-    pub sockets: Option<SocketsInt>,
+    pub sockets: Option<std::num::NonZeroU64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Configure additional enhancements for SPICE."]
     #[doc = ""]
@@ -2381,80 +2441,6 @@ impl<'de> ::serde::Deserialize<'de> for BackgroundDelayInt {
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct BalloonInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for BalloonInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for BalloonInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for BalloonInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for BalloonInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct CoresInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for CoresInt {
-    const MIN: Option<i128> = Some(1i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = Some(1i128);
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 1";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for CoresInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for CoresInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for CoresInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
 pub struct CpuunitsInt(i128);
 impl crate::types::bounded_integer::BoundedInteger for CpuunitsInt {
     const MIN: Option<i128> = Some(1i128);
@@ -2492,43 +2478,6 @@ impl<'de> ::serde::Deserialize<'de> for CpuunitsInt {
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct MigrateSpeedInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for MigrateSpeedInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = Some(0i128);
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for MigrateSpeedInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for MigrateSpeedInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for MigrateSpeedInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
 pub struct SharesInt(i128);
 impl crate::types::bounded_integer::BoundedInteger for SharesInt {
     const MIN: Option<i128> = Some(0i128);
@@ -2558,80 +2507,6 @@ impl ::serde::Serialize for SharesInt {
     }
 }
 impl<'de> ::serde::Deserialize<'de> for SharesInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct SmpInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for SmpInt {
-    const MIN: Option<i128> = Some(1i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = Some(1i128);
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 1";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for SmpInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for SmpInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for SmpInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct SocketsInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for SocketsInt {
-    const MIN: Option<i128> = Some(1i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = Some(1i128);
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 1";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for SocketsInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for SocketsInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for SocketsInt {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: ::serde::Deserializer<'de>,

--- a/proxmox-api/src/generated/nodes/node/qemu/vmid/firewall/log.rs
+++ b/proxmox-api/src/generated/nodes/node/qemu/vmid/firewall/log.rs
@@ -55,170 +55,38 @@ pub struct GetOutputItems {
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]
 pub struct GetParams {
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub limit: Option<LimitInt>,
+    pub limit: Option<u64>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Display log since this UNIX epoch."]
     #[doc = ""]
-    pub since: Option<SinceInt>,
+    pub since: Option<u64>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub start: Option<StartInt>,
+    pub start: Option<u64>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Display log until this UNIX epoch."]
     #[doc = ""]
-    pub until: Option<UntilInt>,
+    pub until: Option<u64>,
     #[serde(
         flatten,
         default,
         skip_serializing_if = "::std::collections::HashMap::is_empty"
     )]
     pub additional_properties: ::std::collections::HashMap<String, ::serde_json::Value>,
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct LimitInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for LimitInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for LimitInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for LimitInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for LimitInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct SinceInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for SinceInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for SinceInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for SinceInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for SinceInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct StartInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for StartInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for StartInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for StartInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for StartInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct UntilInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for UntilInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for UntilInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for UntilInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for UntilInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
 }

--- a/proxmox-api/src/generated/nodes/node/qemu/vmid/firewall/rules.rs
+++ b/proxmox-api/src/generated/nodes/node/qemu/vmid/firewall/rules.rs
@@ -102,10 +102,14 @@ pub struct PostParams {
     #[doc = "Restrict TCP/UDP destination port. You can use service names or simple numbers (0-65535), as defined in '/etc/services'. Port ranges can be specified with '\\d+:\\d+', for example '80:85', and you can use comma separated list to match several ports or ranges."]
     #[doc = ""]
     pub dport: Option<String>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Flag to enable/disable a rule."]
     #[doc = ""]
-    pub enable: Option<EnableInt>,
+    pub enable: Option<u64>,
     #[serde(rename = "icmp-type")]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Specify icmp-type. Only valid if proto equals 'icmp' or 'icmpv6'/'ipv6-icmp'."]
@@ -124,10 +128,14 @@ pub struct PostParams {
     #[doc = "Use predefined standard macro."]
     #[doc = ""]
     pub macro_def: Option<MacroStr>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Update rule at position \\\\<pos\\\\>."]
     #[doc = ""]
-    pub pos: Option<PosInt>,
+    pub pos: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "IP protocol. You can use protocol names ('tcp'/'udp') or simple numbers, as defined in '/etc/protocols'."]
     #[doc = ""]
@@ -211,80 +219,6 @@ impl TryFrom<&str> for Type {
             "out" => Ok(Self::Out),
             v => Err(format!("Unknown variant {v}")),
         }
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct EnableInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for EnableInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for EnableInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for EnableInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for EnableInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct PosInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for PosInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for PosInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for PosInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for PosInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
     }
 }
 #[derive(Debug, Clone, PartialEq, PartialOrd)]

--- a/proxmox-api/src/generated/nodes/node/qemu/vmid/firewall/rules/pos.rs
+++ b/proxmox-api/src/generated/nodes/node/qemu/vmid/firewall/rules/pos.rs
@@ -161,10 +161,14 @@ pub struct PutParams {
     #[doc = "Restrict TCP/UDP destination port. You can use service names or simple numbers (0-65535), as defined in '/etc/services'. Port ranges can be specified with '\\d+:\\d+', for example '80:85', and you can use comma separated list to match several ports or ranges."]
     #[doc = ""]
     pub dport: Option<String>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Flag to enable/disable a rule."]
     #[doc = ""]
-    pub enable: Option<EnableInt>,
+    pub enable: Option<u64>,
     #[serde(rename = "icmp-type")]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Specify icmp-type. Only valid if proto equals 'icmp' or 'icmpv6'/'ipv6-icmp'."]
@@ -183,10 +187,14 @@ pub struct PutParams {
     #[doc = "Use predefined standard macro."]
     #[doc = ""]
     pub macro_def: Option<MacroStr>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Move rule to new position \\\\<moveto\\\\>. Other arguments are ignored."]
     #[doc = ""]
-    pub moveto: Option<MovetoInt>,
+    pub moveto: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "IP protocol. You can use protocol names ('tcp'/'udp') or simple numbers, as defined in '/etc/protocols'."]
     #[doc = ""]
@@ -271,80 +279,6 @@ impl TryFrom<&str> for Type {
             "out" => Ok(Self::Out),
             v => Err(format!("Unknown variant {v}")),
         }
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct EnableInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for EnableInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for EnableInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for EnableInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for EnableInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct MovetoInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for MovetoInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for MovetoInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for MovetoInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for MovetoInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
     }
 }
 #[derive(Debug, Clone, PartialEq, PartialOrd)]

--- a/proxmox-api/src/generated/nodes/node/qemu/vmid/migrate.rs
+++ b/proxmox-api/src/generated/nodes/node/qemu/vmid/migrate.rs
@@ -102,10 +102,14 @@ impl PostParams {
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize)]
 pub struct PostParams {
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Override I/O bandwidth limit (in KiB/s)."]
     #[doc = ""]
-    pub bwlimit: Option<BwlimitInt>,
+    pub bwlimit: Option<u64>,
     #[serde(
         serialize_with = "crate::types::serialize_bool_optional",
         deserialize_with = "crate::types::deserialize_bool_optional"
@@ -170,42 +174,5 @@ impl TryFrom<&str> for MigrationType {
             "secure" => Ok(Self::Secure),
             v => Err(format!("Unknown variant {v}")),
         }
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct BwlimitInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for BwlimitInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for BwlimitInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for BwlimitInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for BwlimitInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
     }
 }

--- a/proxmox-api/src/generated/nodes/node/qemu/vmid/move_disk.rs
+++ b/proxmox-api/src/generated/nodes/node/qemu/vmid/move_disk.rs
@@ -43,10 +43,14 @@ impl PostParams {
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize)]
 pub struct PostParams {
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Override I/O bandwidth limit (in KiB/s)."]
     #[doc = ""]
-    pub bwlimit: Option<BwlimitInt>,
+    pub bwlimit: Option<u64>,
     #[serde(
         serialize_with = "crate::types::serialize_bool_optional",
         deserialize_with = "crate::types::deserialize_bool_optional"
@@ -2032,43 +2036,6 @@ impl TryFrom<&str> for TargetDisk {
             "virtio9" => Ok(Self::Virtio9),
             v => Err(format!("Unknown variant {v}")),
         }
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct BwlimitInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for BwlimitInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for BwlimitInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for BwlimitInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for BwlimitInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]

--- a/proxmox-api/src/generated/nodes/node/qemu/vmid/remote_migrate.rs
+++ b/proxmox-api/src/generated/nodes/node/qemu/vmid/remote_migrate.rs
@@ -41,10 +41,14 @@ impl PostParams {
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize)]
 pub struct PostParams {
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Override I/O bandwidth limit (in KiB/s)."]
     #[doc = ""]
-    pub bwlimit: Option<BwlimitInt>,
+    pub bwlimit: Option<u64>,
     #[serde(
         serialize_with = "crate::types::serialize_bool_optional",
         deserialize_with = "crate::types::deserialize_bool_optional"
@@ -84,43 +88,6 @@ pub struct PostParams {
         skip_serializing_if = "::std::collections::HashMap::is_empty"
     )]
     pub additional_properties: ::std::collections::HashMap<String, ::serde_json::Value>,
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct BwlimitInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for BwlimitInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for BwlimitInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for BwlimitInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for BwlimitInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
 }
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
 pub struct TargetVmidInt(i128);

--- a/proxmox-api/src/generated/nodes/node/qemu/vmid/status/reboot.rs
+++ b/proxmox-api/src/generated/nodes/node/qemu/vmid/status/reboot.rs
@@ -27,51 +27,18 @@ where
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]
 pub struct PostParams {
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Wait maximal timeout seconds for the shutdown."]
     #[doc = ""]
-    pub timeout: Option<TimeoutInt>,
+    pub timeout: Option<u64>,
     #[serde(
         flatten,
         default,
         skip_serializing_if = "::std::collections::HashMap::is_empty"
     )]
     pub additional_properties: ::std::collections::HashMap<String, ::serde_json::Value>,
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct TimeoutInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for TimeoutInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for TimeoutInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for TimeoutInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for TimeoutInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
 }

--- a/proxmox-api/src/generated/nodes/node/qemu/vmid/status/shutdown.rs
+++ b/proxmox-api/src/generated/nodes/node/qemu/vmid/status/shutdown.rs
@@ -53,51 +53,18 @@ pub struct PostParams {
     #[doc = "Ignore locks - only root is allowed to use this option."]
     #[doc = ""]
     pub skiplock: Option<bool>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Wait maximal timeout seconds."]
     #[doc = ""]
-    pub timeout: Option<TimeoutInt>,
+    pub timeout: Option<u64>,
     #[serde(
         flatten,
         default,
         skip_serializing_if = "::std::collections::HashMap::is_empty"
     )]
     pub additional_properties: ::std::collections::HashMap<String, ::serde_json::Value>,
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct TimeoutInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for TimeoutInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for TimeoutInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for TimeoutInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for TimeoutInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
 }

--- a/proxmox-api/src/generated/nodes/node/qemu/vmid/status/start.rs
+++ b/proxmox-api/src/generated/nodes/node/qemu/vmid/status/start.rs
@@ -64,10 +64,14 @@ pub struct PostParams {
     #[doc = "Mapping from source to target storages. Providing only a single storage ID maps all source storages to that storage. Providing the special value '1' will map each source storage to itself."]
     #[doc = ""]
     pub targetstorage: Option<String>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Wait maximal timeout seconds."]
     #[doc = ""]
-    pub timeout: Option<TimeoutInt>,
+    pub timeout: Option<u64>,
     #[serde(
         flatten,
         default,
@@ -92,43 +96,6 @@ impl TryFrom<&str> for MigrationType {
             "secure" => Ok(Self::Secure),
             v => Err(format!("Unknown variant {v}")),
         }
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct TimeoutInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for TimeoutInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for TimeoutInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for TimeoutInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for TimeoutInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
     }
 }
 #[derive(Debug, Clone, PartialEq, PartialOrd)]

--- a/proxmox-api/src/generated/nodes/node/qemu/vmid/status/stop.rs
+++ b/proxmox-api/src/generated/nodes/node/qemu/vmid/status/stop.rs
@@ -57,51 +57,18 @@ pub struct PostParams {
     #[doc = "Ignore locks - only root is allowed to use this option."]
     #[doc = ""]
     pub skiplock: Option<bool>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Wait maximal timeout seconds."]
     #[doc = ""]
-    pub timeout: Option<TimeoutInt>,
+    pub timeout: Option<u64>,
     #[serde(
         flatten,
         default,
         skip_serializing_if = "::std::collections::HashMap::is_empty"
     )]
     pub additional_properties: ::std::collections::HashMap<String, ::serde_json::Value>,
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct TimeoutInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for TimeoutInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for TimeoutInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for TimeoutInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for TimeoutInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
 }

--- a/proxmox-api/src/generated/nodes/node/replication/id/log.rs
+++ b/proxmox-api/src/generated/nodes/node/replication/id/log.rs
@@ -55,88 +55,22 @@ pub struct GetOutputItems {
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]
 pub struct GetParams {
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub limit: Option<LimitInt>,
+    pub limit: Option<u64>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub start: Option<StartInt>,
+    pub start: Option<u64>,
     #[serde(
         flatten,
         default,
         skip_serializing_if = "::std::collections::HashMap::is_empty"
     )]
     pub additional_properties: ::std::collections::HashMap<String, ::serde_json::Value>,
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct LimitInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for LimitInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for LimitInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for LimitInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for LimitInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct StartInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for StartInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for StartInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for StartInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for StartInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
 }

--- a/proxmox-api/src/generated/nodes/node/storage/storage/content.rs
+++ b/proxmox-api/src/generated/nodes/node/storage/storage/content.rs
@@ -57,10 +57,14 @@ impl GetOutputItems {
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize)]
 pub struct GetOutputItems {
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Creation time (seconds since the UNIX Epoch)."]
     #[doc = ""]
-    pub ctime: Option<CtimeInt>,
+    pub ctime: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "If whole backup is encrypted, value is the fingerprint or '1'  if encrypted. Only useful for the Proxmox Backup Server storage type."]
     #[doc = ""]
@@ -211,43 +215,6 @@ impl TryFrom<&str> for Format {
             "subvol" => Ok(Self::Subvol),
             v => Err(format!("Unknown variant {v}")),
         }
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct CtimeInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for CtimeInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for CtimeInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for CtimeInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for CtimeInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]

--- a/proxmox-api/src/generated/nodes/node/syslog.rs
+++ b/proxmox-api/src/generated/nodes/node/syslog.rs
@@ -55,8 +55,12 @@ pub struct GetOutputItems {
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]
 pub struct GetParams {
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub limit: Option<LimitInt>,
+    pub limit: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Service ID"]
     #[doc = ""]
@@ -65,8 +69,12 @@ pub struct GetParams {
     #[doc = "Display all log since this date-time string."]
     #[doc = ""]
     pub since: Option<SinceStr>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub start: Option<StartInt>,
+    pub start: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Display all log until this date-time string."]
     #[doc = ""]
@@ -77,80 +85,6 @@ pub struct GetParams {
         skip_serializing_if = "::std::collections::HashMap::is_empty"
     )]
     pub additional_properties: ::std::collections::HashMap<String, ::serde_json::Value>,
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct LimitInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for LimitInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for LimitInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for LimitInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for LimitInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct StartInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for StartInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for StartInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for StartInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for StartInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
 }
 #[derive(Debug, Clone, PartialEq, PartialOrd)]
 pub struct ServiceStr {

--- a/proxmox-api/src/generated/nodes/node/tasks.rs
+++ b/proxmox-api/src/generated/nodes/node/tasks.rs
@@ -116,10 +116,14 @@ pub struct GetParams {
     #[doc = "List archived, active or all tasks."]
     #[doc = ""]
     pub source: Option<Source>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "List tasks beginning from this offset."]
     #[doc = ""]
-    pub start: Option<StartInt>,
+    pub start: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "List of Task States that should be returned."]
     #[doc = ""]
@@ -204,43 +208,6 @@ impl ::serde::Serialize for LimitInt {
     }
 }
 impl<'de> ::serde::Deserialize<'de> for LimitInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct StartInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for StartInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = Some(0i128);
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for StartInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for StartInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for StartInt {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: ::serde::Deserializer<'de>,

--- a/proxmox-api/src/generated/nodes/node/tasks/upid/log.rs
+++ b/proxmox-api/src/generated/nodes/node/tasks/upid/log.rs
@@ -67,10 +67,14 @@ pub struct GetParams {
     #[doc = "The amount of lines to read from the tasklog."]
     #[doc = ""]
     pub limit: Option<LimitInt>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Start at this line when reading the tasklog"]
     #[doc = ""]
-    pub start: Option<StartInt>,
+    pub start: Option<u64>,
     #[serde(
         flatten,
         default,
@@ -108,43 +112,6 @@ impl ::serde::Serialize for LimitInt {
     }
 }
 impl<'de> ::serde::Deserialize<'de> for LimitInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct StartInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for StartInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = Some(0i128);
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for StartInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for StartInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for StartInt {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: ::serde::Deserializer<'de>,

--- a/proxmox-api/src/generated/nodes/node/vzdump.rs
+++ b/proxmox-api/src/generated/nodes/node/vzdump.rs
@@ -37,10 +37,14 @@ pub struct PostParams {
     #[doc = "Backup all known guest systems on this host."]
     #[doc = ""]
     pub all: Option<bool>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Limit I/O bandwidth (in KiB/s)."]
     #[doc = ""]
-    pub bwlimit: Option<BwlimitInt>,
+    pub bwlimit: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Compress dump file."]
     #[doc = ""]
@@ -78,10 +82,14 @@ pub struct PostParams {
     #[doc = "Deprecated: Use notification targets/matchers instead. Comma-separated list of email addresses or users that should receive email notifications."]
     #[doc = ""]
     pub mailto: Option<String>,
+    #[serde(
+        serialize_with = "crate::types::serialize_non_zero_pos_int_optional",
+        deserialize_with = "crate::types::deserialize_non_zero_pos_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Deprecated: use 'prune-backups' instead. Maximal number of backup files per guest system."]
     #[doc = ""]
-    pub maxfiles: Option<MaxfilesInt>,
+    pub maxfiles: Option<std::num::NonZeroU64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Backup mode."]
     #[doc = ""]
@@ -110,10 +118,14 @@ pub struct PostParams {
     #[doc = "Other performance-related settings."]
     #[doc = ""]
     pub performance: Option<String>,
+    #[serde(
+        serialize_with = "crate::types::serialize_int_optional",
+        deserialize_with = "crate::types::deserialize_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Use pigz instead of gzip when N\\\\>0. N=1 uses half of cores, N\\\\>1 uses N as thread count."]
     #[doc = ""]
-    pub pigz: Option<PigzInt>,
+    pub pigz: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Backup all known guest systems included in the specified pool."]
     #[doc = ""]
@@ -321,43 +333,6 @@ impl TryFrom<&str> for NotificationPolicy {
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct BwlimitInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for BwlimitInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = Some(0i128);
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for BwlimitInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for BwlimitInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for BwlimitInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
 pub struct IoniceInt(i128);
 impl crate::types::bounded_integer::BoundedInteger for IoniceInt {
     const MIN: Option<i128> = Some(0i128);
@@ -424,80 +399,6 @@ impl ::serde::Serialize for LockwaitInt {
     }
 }
 impl<'de> ::serde::Deserialize<'de> for LockwaitInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct MaxfilesInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for MaxfilesInt {
-    const MIN: Option<i128> = Some(1i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 1";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for MaxfilesInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for MaxfilesInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for MaxfilesInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct PigzInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for PigzInt {
-    const MIN: Option<i128> = None::<i128>;
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = Some(0i128);
-    const TYPE_DESCRIPTION: &'static str = "a valid integer";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for PigzInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for PigzInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for PigzInt {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: ::serde::Deserializer<'de>,

--- a/proxmox-api/src/generated/nodes/node/vzdump/defaults.rs
+++ b/proxmox-api/src/generated/nodes/node/vzdump/defaults.rs
@@ -35,10 +35,14 @@ pub struct GetOutput {
     #[doc = "Backup all known guest systems on this host."]
     #[doc = ""]
     pub all: Option<bool>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Limit I/O bandwidth (in KiB/s)."]
     #[doc = ""]
-    pub bwlimit: Option<BwlimitInt>,
+    pub bwlimit: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Compress dump file."]
     #[doc = ""]
@@ -76,10 +80,14 @@ pub struct GetOutput {
     #[doc = "Deprecated: Use notification targets/matchers instead. Comma-separated list of email addresses or users that should receive email notifications."]
     #[doc = ""]
     pub mailto: Option<String>,
+    #[serde(
+        serialize_with = "crate::types::serialize_non_zero_pos_int_optional",
+        deserialize_with = "crate::types::deserialize_non_zero_pos_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Deprecated: use 'prune-backups' instead. Maximal number of backup files per guest system."]
     #[doc = ""]
-    pub maxfiles: Option<MaxfilesInt>,
+    pub maxfiles: Option<std::num::NonZeroU64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Backup mode."]
     #[doc = ""]
@@ -112,10 +120,14 @@ pub struct GetOutput {
     #[doc = "Other performance-related settings."]
     #[doc = ""]
     pub performance: Option<String>,
+    #[serde(
+        serialize_with = "crate::types::serialize_int_optional",
+        deserialize_with = "crate::types::deserialize_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Use pigz instead of gzip when N\\\\>0. N=1 uses half of cores, N\\\\>1 uses N as thread count."]
     #[doc = ""]
-    pub pigz: Option<PigzInt>,
+    pub pigz: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Backup all known guest systems included in the specified pool."]
     #[doc = ""]
@@ -322,43 +334,6 @@ impl TryFrom<&str> for NotificationPolicy {
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct BwlimitInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for BwlimitInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = Some(0i128);
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for BwlimitInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for BwlimitInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for BwlimitInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
 pub struct IoniceInt(i128);
 impl crate::types::bounded_integer::BoundedInteger for IoniceInt {
     const MIN: Option<i128> = Some(0i128);
@@ -425,80 +400,6 @@ impl ::serde::Serialize for LockwaitInt {
     }
 }
 impl<'de> ::serde::Deserialize<'de> for LockwaitInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct MaxfilesInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for MaxfilesInt {
-    const MIN: Option<i128> = Some(1i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 1";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for MaxfilesInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for MaxfilesInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for MaxfilesInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct PigzInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for PigzInt {
-    const MIN: Option<i128> = None::<i128>;
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = Some(0i128);
-    const TYPE_DESCRIPTION: &'static str = "a valid integer";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for PigzInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for PigzInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for PigzInt {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: ::serde::Deserializer<'de>,

--- a/proxmox-api/src/generated/storage.rs
+++ b/proxmox-api/src/generated/storage.rs
@@ -322,10 +322,14 @@ pub struct PostParams {
     #[doc = "Maximal number of protected backups per guest. Use '-1' for unlimited."]
     #[doc = ""]
     pub max_protected_backups: Option<MaxProtectedBackupsInt>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Deprecated: use 'prune-backups' instead. Maximal number of backup files per VM. Use '0' for unlimited."]
     #[doc = ""]
-    pub maxfiles: Option<MaxfilesInt>,
+    pub maxfiles: Option<u64>,
     #[serde(
         serialize_with = "crate::types::serialize_bool_optional",
         deserialize_with = "crate::types::deserialize_bool_optional"
@@ -670,43 +674,6 @@ impl ::serde::Serialize for MaxProtectedBackupsInt {
     }
 }
 impl<'de> ::serde::Deserialize<'de> for MaxProtectedBackupsInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct MaxfilesInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for MaxfilesInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for MaxfilesInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for MaxfilesInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for MaxfilesInt {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: ::serde::Deserializer<'de>,

--- a/proxmox-api/src/generated/storage/storage.rs
+++ b/proxmox-api/src/generated/storage/storage.rs
@@ -228,10 +228,14 @@ pub struct PutParams {
     #[doc = "Maximal number of protected backups per guest. Use '-1' for unlimited."]
     #[doc = ""]
     pub max_protected_backups: Option<MaxProtectedBackupsInt>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[doc = "Deprecated: use 'prune-backups' instead. Maximal number of backup files per VM. Use '0' for unlimited."]
     #[doc = ""]
-    pub maxfiles: Option<MaxfilesInt>,
+    pub maxfiles: Option<u64>,
     #[serde(
         serialize_with = "crate::types::serialize_bool_optional",
         deserialize_with = "crate::types::deserialize_bool_optional"
@@ -541,43 +545,6 @@ impl ::serde::Serialize for MaxProtectedBackupsInt {
     }
 }
 impl<'de> ::serde::Deserialize<'de> for MaxProtectedBackupsInt {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'de>,
-    {
-        crate::types::bounded_integer::deserialize_bounded_integer(deserializer)
-    }
-}
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct MaxfilesInt(i128);
-impl crate::types::bounded_integer::BoundedInteger for MaxfilesInt {
-    const MIN: Option<i128> = Some(0i128);
-    const MAX: Option<i128> = None::<i128>;
-    const DEFAULT: Option<i128> = None::<i128>;
-    const TYPE_DESCRIPTION: &'static str = "an integer greater than or equal to 0";
-    fn get(&self) -> i128 {
-        self.0
-    }
-    fn new(value: i128) -> Result<Self, crate::types::bounded_integer::BoundedIntegerError> {
-        Self::validate(value)?;
-        Ok(Self(value))
-    }
-}
-impl std::convert::TryFrom<i128> for MaxfilesInt {
-    type Error = crate::types::bounded_integer::BoundedIntegerError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        crate::types::bounded_integer::BoundedInteger::new(value)
-    }
-}
-impl ::serde::Serialize for MaxfilesInt {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        crate::types::bounded_integer::serialize_bounded_integer(self, serializer)
-    }
-}
-impl<'de> ::serde::Deserialize<'de> for MaxfilesInt {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: ::serde::Deserializer<'de>,

--- a/proxmox-api/src/types/mod.rs
+++ b/proxmox-api/src/types/mod.rs
@@ -18,10 +18,22 @@ pub use multi::{deserialize_additional_data, deserialize_multi, serialize_multi}
 mod mac_addr;
 pub use mac_addr::MacAddr;
 
+mod non_zero_pos_integer;
+pub use non_zero_pos_integer::{
+    NonZeroUnsignedInteger, deserialize_non_zero_pos_int, deserialize_non_zero_pos_int_optional,
+    serialize_non_zero_pos_int, serialize_non_zero_pos_int_optional,
+};
+
 mod number;
 pub use number::{
     Number, deserialize_number, deserialize_number_optional, serialize_number,
     serialize_number_optional,
+};
+
+mod unsigned_integer;
+pub use unsigned_integer::{
+    UnsignedInteger, deserialize_unsigned_int, deserialize_unsigned_int_optional,
+    serialize_unsigned_int, serialize_unsigned_int_optional,
 };
 
 mod vmid;

--- a/proxmox-api/src/types/non_zero_pos_integer.rs
+++ b/proxmox-api/src/types/non_zero_pos_integer.rs
@@ -1,0 +1,91 @@
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::num::NonZeroU64;
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct NonZeroUnsignedInteger(
+    #[serde(
+        serialize_with = "serialize_non_zero_pos_int",
+        deserialize_with = "deserialize_non_zero_pos_int"
+    )]
+    pub NonZeroU64,
+);
+
+impl NonZeroUnsignedInteger {
+    pub fn get(&self) -> NonZeroU64 {
+        self.0
+    }
+}
+
+pub fn deserialize_non_zero_pos_int<'de, D>(d: D) -> Result<NonZeroU64, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct Visitor;
+
+    impl<'v> serde::de::Visitor<'v> for Visitor {
+        type Value = NonZeroU64;
+
+        fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            write!(
+                f,
+                "a non-zero positive integer or string encoding a non-zero positive integer"
+            )
+        }
+
+        fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            NonZeroU64::new(v).ok_or_else(|| E::custom("value must be non-zero"))
+        }
+
+        fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            if v <= 0 {
+                Err(E::custom("value must be positive and non-zero"))
+            } else {
+                NonZeroU64::new(v as u64).ok_or_else(|| E::custom("value must be non-zero"))
+            }
+        }
+
+        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            if let Ok(value) = v.parse::<u64>() {
+                NonZeroU64::new(value).ok_or_else(|| E::custom("value must be non-zero"))
+            } else {
+                Err(E::custom("invalid value for non-zero positive integer"))
+            }
+        }
+    }
+
+    d.deserialize_any(Visitor)
+}
+
+pub fn serialize_non_zero_pos_int<S>(value: &NonZeroU64, s: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    s.serialize_u64(value.get())
+}
+
+pub fn deserialize_non_zero_pos_int_optional<'de, D>(d: D) -> Result<Option<NonZeroU64>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let v = Option::<NonZeroUnsignedInteger>::deserialize(d);
+    Ok(v?.map(|v| v.get()))
+}
+
+pub fn serialize_non_zero_pos_int_optional<S>(
+    value: &Option<NonZeroU64>,
+    s: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    value.map(NonZeroUnsignedInteger).serialize(s)
+}

--- a/proxmox-api/src/types/unsigned_integer.rs
+++ b/proxmox-api/src/types/unsigned_integer.rs
@@ -1,0 +1,87 @@
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct UnsignedInteger(
+    #[serde(
+        serialize_with = "serialize_unsigned_int",
+        deserialize_with = "deserialize_unsigned_int"
+    )]
+    pub u64,
+);
+
+impl UnsignedInteger {
+    pub fn get(&self) -> u64 {
+        self.0
+    }
+}
+
+pub fn deserialize_unsigned_int<'de, D>(d: D) -> Result<u64, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct Visitor;
+
+    impl<'v> serde::de::Visitor<'v> for Visitor {
+        type Value = u64;
+
+        fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            write!(
+                f,
+                "an unsigned integer or string encoding an unsigned integer"
+            )
+        }
+
+        fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(v)
+        }
+
+        fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            if v < 0 {
+                Err(E::custom("invalid value for unsigned integer"))
+            } else {
+                Ok(v as u64)
+            }
+        }
+
+        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            if let Ok(value) = v.parse::<u64>() {
+                Ok(value)
+            } else {
+                Err(E::custom("invalid value for unsigned integer"))
+            }
+        }
+    }
+
+    d.deserialize_any(Visitor)
+}
+
+pub fn serialize_unsigned_int<S>(value: &u64, s: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    s.serialize_u64(*value)
+}
+
+pub fn deserialize_unsigned_int_optional<'de, D>(d: D) -> Result<Option<u64>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let v = Option::<UnsignedInteger>::deserialize(d);
+    Ok(v?.map(|v| v.get()))
+}
+
+pub fn serialize_unsigned_int_optional<S>(value: &Option<u64>, s: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    value.map(UnsignedInteger).serialize(s)
+}


### PR DESCRIPTION
Lets use more primitive types in the generated code. This allows us to reduce the number of autogenerated types (for a minimal amount).