### PR TITLE
Update API clients to return empty arrays for non-error array responses

### DIFF
--- a/proxmox-api/src/clients/reqwest.rs
+++ b/proxmox-api/src/clients/reqwest.rs
@@ -201,7 +201,11 @@ impl crate::client::Client for Client {
         } else if let Some(errors) = result.errors {
             Err(Error::EncounteredErrors(errors))
         } else {
-            Err(Error::UnknownFailure(response_status))
+            // PVE sometimes returns {"data":null} for array endpoints that have no
+            // data (e.g. LXC container network interfaces), so return an empty array
+            // if we got a non-error response to an array endpoint, but it was empty.
+            serde_json::from_value(serde_json::Value::Array(vec![]))
+                .or_else(|_| Err(Error::UnknownFailure(response_status)))
         }
     }
 }

--- a/proxmox-api/src/clients/reqwest.rs
+++ b/proxmox-api/src/clients/reqwest.rs
@@ -205,7 +205,7 @@ impl crate::client::Client for Client {
             // data (e.g. LXC container network interfaces), so return an empty array
             // if we got a non-error response to an array endpoint, but it was empty.
             serde_json::from_value(serde_json::Value::Array(vec![]))
-                .or_else(|_| Err(Error::UnknownFailure(response_status)))
+                .map_err(|_| Error::UnknownFailure(response_status))
         }
     }
 }

--- a/proxmox-api/src/clients/ureq.rs
+++ b/proxmox-api/src/clients/ureq.rs
@@ -263,7 +263,7 @@ impl crate::client::Client for Client {
             // data (e.g. LXC container network interfaces), so return an empty array
             // if we got a non-error response to an array endpoint, but it was empty.
             serde_json::from_value(serde_json::Value::Array(vec![]))
-                .or_else(|_| Err(Error::UnknownFailure))
+                .map_err(|_| Error::UnknownFailure)
         }
     }
 }

--- a/proxmox-api/src/clients/ureq.rs
+++ b/proxmox-api/src/clients/ureq.rs
@@ -259,7 +259,11 @@ impl crate::client::Client for Client {
         } else if let Some(errors) = result.errors {
             Err(Error::EncounteredErrors(errors))
         } else {
-            Err(Error::UnknownFailure)
+            // PVE sometimes returns {"data":null} for array endpoints that have no
+            // data (e.g. LXC container network interfaces), so return an empty array
+            // if we got a non-error response to an array endpoint, but it was empty.
+            serde_json::from_value(serde_json::Value::Array(vec![]))
+                .or_else(|_| Err(Error::UnknownFailure))
         }
     }
 }


### PR DESCRIPTION
Open to feedback here if there's a better way to accomplish this.

PVE sometimes returns `{"data":null}` for array endpoints that have no data which causes an `UnknownError` to be raised.

My example was an LXC container that had no network interfaces. The `GET /nodes/<node>/lxc/<vmid>/interfaces` endpoint returned `{"data":null}`. I went w/ this approach because it seemed more semantically correct for "array-like" endpoints.