### PR TITLE
Enable documentation for Reqwest client

### DIFF
--- a/proxmox-api/Cargo.toml
+++ b/proxmox-api/Cargo.toml
@@ -14,6 +14,9 @@ documentation = "https://docs.rs/proxmox-api/"
 debian-distro = "bookworm"
 pve-version = "9.1.2"
 
+[package.metadata.docs.rs]
+features = ["default", "reqwest-client"]
+
 [features]
 default = [ "access", "cluster", "nodes", "pools", "storage", "version" ]
 access = []


### PR DESCRIPTION
This makes the Reqwest client more discoverable when browsing the documentation.