### PR TITLE
Support authenticating with existing ticket

### DIFF
--- a/proxmox-api/src/clients/reqwest.rs
+++ b/proxmox-api/src/clients/reqwest.rs
@@ -68,6 +68,12 @@ impl Client {
         Ok(self)
     }
 
+    pub async fn with_ticket(self, ticket: &str, csrf: &str) -> Result<Self, Error> {
+        self.auth_state.set_csrf(ticket.into(), csrf.into());
+        self.refresh_auth_ticket(true).await?;
+        Ok(self)
+    }
+
     fn route(&self, path: &str) -> String {
         format!("{}/api2/json{}", self.host, path)
     }


### PR DESCRIPTION
This is a useful escape hatch in scenarios where authentication has been performed another way (e.g. by directly using the ticket API exposed by this crate).

An example use-case is where the ticket API has been used for 2FA or OIDC based login.