### PR TITLE
Allow Reqwest client reuse

### DIFF
--- a/proxmox-api/src/clients/reqwest.rs
+++ b/proxmox-api/src/clients/reqwest.rs
@@ -43,12 +43,9 @@ impl Client {
         )
     }
 
-    pub fn new(host: &str, user: &str, realm: &str, client: Option<reqwest::Client>) -> Self {
+    pub fn new(host: &str, user: &str, realm: &str, client: Option<Arc<reqwest::Client>>) -> Self {
         Self {
-            client: match client {
-                None => Self::client(),
-                Some(client) => Arc::new(client),
-            },
+            client: client.unwrap_or_else(Self::client),
             host: host.to_string(),
             user: user.into(),
             realm: realm.into(),


### PR DESCRIPTION
This change makes it possible to pass in an existing Request client instance, which makes it possible to share the client and benefit from re-use of the connection pool and other state within the client instance. It slightly complicates the use of the function as people need to additionally construct an Arc<_>, but it fundamentally removes a limitation of the current API.