### PR TITLE
fix!: arrays-returning calls can return null for empty arrays

### DIFF
--- a/generator/src/generator/mod.rs
+++ b/generator/src/generator/mod.rs
@@ -149,6 +149,15 @@ impl Generator {
 
                         let call = Self::to_call(def.primitive(), &fn_name, defer_signature);
 
+                        let call = if matches!(def, TypeDef::Array(_)) {
+                            quote! {
+                                let optional_vec: Option<#name> = #call?;
+                                Ok(optional_vec.unwrap_or_default())
+                            }
+                        } else {
+                            call
+                        };
+
                         (quote! { -> Result<#name, T::Error> }, call)
                     } else {
                         (

--- a/proxmox-api/src/generated/access.rs
+++ b/proxmox-api/src/generated/access.rs
@@ -33,7 +33,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/access/acl.rs
+++ b/proxmox-api/src/generated/access/acl.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> AclClient<T>

--- a/proxmox-api/src/generated/access/domains.rs
+++ b/proxmox-api/src/generated/access/domains.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> DomainsClient<T>

--- a/proxmox-api/src/generated/access/groups.rs
+++ b/proxmox-api/src/generated/access/groups.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> GroupsClient<T>

--- a/proxmox-api/src/generated/access/openid.rs
+++ b/proxmox-api/src/generated/access/openid.rs
@@ -24,7 +24,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/access/roles.rs
+++ b/proxmox-api/src/generated/access/roles.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> RolesClient<T>

--- a/proxmox-api/src/generated/access/tfa.rs
+++ b/proxmox-api/src/generated/access/tfa.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl EntriesGetOutputItemsEntriesItems {

--- a/proxmox-api/src/generated/access/tfa/userid.rs
+++ b/proxmox-api/src/generated/access/tfa/userid.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> UseridClient<T>

--- a/proxmox-api/src/generated/access/users.rs
+++ b/proxmox-api/src/generated/access/users.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self, params: GetParams) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &params).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &params).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> UsersClient<T>

--- a/proxmox-api/src/generated/access/users/userid/token.rs
+++ b/proxmox-api/src/generated/access/users/userid/token.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/cluster.rs
+++ b/proxmox-api/src/generated/cluster.rs
@@ -42,7 +42,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]

--- a/proxmox-api/src/generated/cluster/acme.rs
+++ b/proxmox-api/src/generated/cluster/acme.rs
@@ -28,7 +28,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]

--- a/proxmox-api/src/generated/cluster/acme/account.rs
+++ b/proxmox-api/src/generated/cluster/acme/account.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> AccountClient<T>

--- a/proxmox-api/src/generated/cluster/acme/challenge_schema.rs
+++ b/proxmox-api/src/generated/cluster/acme/challenge_schema.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/cluster/acme/directories.rs
+++ b/proxmox-api/src/generated/cluster/acme/directories.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/cluster/acme/plugins.rs
+++ b/proxmox-api/src/generated/cluster/acme/plugins.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self, params: GetParams) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &params).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &params).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> PluginsClient<T>

--- a/proxmox-api/src/generated/cluster/backup.rs
+++ b/proxmox-api/src/generated/cluster/backup.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> BackupClient<T>

--- a/proxmox-api/src/generated/cluster/backup_info.rs
+++ b/proxmox-api/src/generated/cluster/backup_info.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/cluster/backup_info/not_backed_up.rs
+++ b/proxmox-api/src/generated/cluster/backup_info/not_backed_up.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/cluster/bulk_action.rs
+++ b/proxmox-api/src/generated/cluster/bulk_action.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]

--- a/proxmox-api/src/generated/cluster/bulk_action/guest.rs
+++ b/proxmox-api/src/generated/cluster/bulk_action/guest.rs
@@ -26,7 +26,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]

--- a/proxmox-api/src/generated/cluster/ceph.rs
+++ b/proxmox-api/src/generated/cluster/ceph.rs
@@ -25,7 +25,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]

--- a/proxmox-api/src/generated/cluster/ceph/flags.rs
+++ b/proxmox-api/src/generated/cluster/ceph/flags.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> FlagsClient<T>

--- a/proxmox-api/src/generated/cluster/config.rs
+++ b/proxmox-api/src/generated/cluster/config.rs
@@ -27,7 +27,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> ConfigClient<T>

--- a/proxmox-api/src/generated/cluster/config/nodes.rs
+++ b/proxmox-api/src/generated/cluster/config/nodes.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/cluster/firewall.rs
+++ b/proxmox-api/src/generated/cluster/firewall.rs
@@ -29,7 +29,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]

--- a/proxmox-api/src/generated/cluster/firewall/aliases.rs
+++ b/proxmox-api/src/generated/cluster/firewall/aliases.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> AliasesClient<T>

--- a/proxmox-api/src/generated/cluster/firewall/groups.rs
+++ b/proxmox-api/src/generated/cluster/firewall/groups.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> GroupsClient<T>

--- a/proxmox-api/src/generated/cluster/firewall/groups/group.rs
+++ b/proxmox-api/src/generated/cluster/firewall/groups/group.rs
@@ -34,7 +34,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> GroupClient<T>

--- a/proxmox-api/src/generated/cluster/firewall/ipset.rs
+++ b/proxmox-api/src/generated/cluster/firewall/ipset.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> IpsetClient<T>

--- a/proxmox-api/src/generated/cluster/firewall/ipset/name.rs
+++ b/proxmox-api/src/generated/cluster/firewall/ipset/name.rs
@@ -34,7 +34,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> NameClient<T>

--- a/proxmox-api/src/generated/cluster/firewall/macros.rs
+++ b/proxmox-api/src/generated/cluster/firewall/macros.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/cluster/firewall/refs.rs
+++ b/proxmox-api/src/generated/cluster/firewall/refs.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self, params: GetParams) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &params).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &params).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/cluster/firewall/rules.rs
+++ b/proxmox-api/src/generated/cluster/firewall/rules.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> RulesClient<T>

--- a/proxmox-api/src/generated/cluster/ha.rs
+++ b/proxmox-api/src/generated/cluster/ha.rs
@@ -26,7 +26,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/cluster/ha/groups.rs
+++ b/proxmox-api/src/generated/cluster/ha/groups.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> GroupsClient<T>

--- a/proxmox-api/src/generated/cluster/ha/resources.rs
+++ b/proxmox-api/src/generated/cluster/ha/resources.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self, params: GetParams) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &params).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &params).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> ResourcesClient<T>

--- a/proxmox-api/src/generated/cluster/ha/rules.rs
+++ b/proxmox-api/src/generated/cluster/ha/rules.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self, params: GetParams) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &params).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &params).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> RulesClient<T>

--- a/proxmox-api/src/generated/cluster/ha/status.rs
+++ b/proxmox-api/src/generated/cluster/ha/status.rs
@@ -24,7 +24,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]

--- a/proxmox-api/src/generated/cluster/ha/status/current.rs
+++ b/proxmox-api/src/generated/cluster/ha/status/current.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/cluster/jobs.rs
+++ b/proxmox-api/src/generated/cluster/jobs.rs
@@ -24,7 +24,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/cluster/jobs/realm_sync.rs
+++ b/proxmox-api/src/generated/cluster/jobs/realm_sync.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/cluster/jobs/schedule_analyze.rs
+++ b/proxmox-api/src/generated/cluster/jobs/schedule_analyze.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self, params: GetParams) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &params).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &params).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/cluster/log.rs
+++ b/proxmox-api/src/generated/cluster/log.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self, params: GetParams) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &params).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &params).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]

--- a/proxmox-api/src/generated/cluster/mapping.rs
+++ b/proxmox-api/src/generated/cluster/mapping.rs
@@ -25,7 +25,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]

--- a/proxmox-api/src/generated/cluster/mapping/dir.rs
+++ b/proxmox-api/src/generated/cluster/mapping/dir.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self, params: GetParams) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &params).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &params).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> DirClient<T>

--- a/proxmox-api/src/generated/cluster/mapping/pci.rs
+++ b/proxmox-api/src/generated/cluster/mapping/pci.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self, params: GetParams) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &params).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &params).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> PciClient<T>

--- a/proxmox-api/src/generated/cluster/mapping/usb.rs
+++ b/proxmox-api/src/generated/cluster/mapping/usb.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self, params: GetParams) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &params).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &params).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> UsbClient<T>

--- a/proxmox-api/src/generated/cluster/metrics.rs
+++ b/proxmox-api/src/generated/cluster/metrics.rs
@@ -24,7 +24,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]

--- a/proxmox-api/src/generated/cluster/metrics/server.rs
+++ b/proxmox-api/src/generated/cluster/metrics/server.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/cluster/notifications.rs
+++ b/proxmox-api/src/generated/cluster/notifications.rs
@@ -27,7 +27,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]

--- a/proxmox-api/src/generated/cluster/notifications/endpoints.rs
+++ b/proxmox-api/src/generated/cluster/notifications/endpoints.rs
@@ -26,7 +26,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]

--- a/proxmox-api/src/generated/cluster/notifications/endpoints/gotify.rs
+++ b/proxmox-api/src/generated/cluster/notifications/endpoints/gotify.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> GotifyClient<T>

--- a/proxmox-api/src/generated/cluster/notifications/endpoints/sendmail.rs
+++ b/proxmox-api/src/generated/cluster/notifications/endpoints/sendmail.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> SendmailClient<T>

--- a/proxmox-api/src/generated/cluster/notifications/endpoints/smtp.rs
+++ b/proxmox-api/src/generated/cluster/notifications/endpoints/smtp.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> SmtpClient<T>

--- a/proxmox-api/src/generated/cluster/notifications/endpoints/webhook.rs
+++ b/proxmox-api/src/generated/cluster/notifications/endpoints/webhook.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> WebhookClient<T>

--- a/proxmox-api/src/generated/cluster/notifications/matcher_field_values.rs
+++ b/proxmox-api/src/generated/cluster/notifications/matcher_field_values.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/cluster/notifications/matcher_fields.rs
+++ b/proxmox-api/src/generated/cluster/notifications/matcher_fields.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/cluster/notifications/matchers.rs
+++ b/proxmox-api/src/generated/cluster/notifications/matchers.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> MatchersClient<T>

--- a/proxmox-api/src/generated/cluster/notifications/targets.rs
+++ b/proxmox-api/src/generated/cluster/notifications/targets.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/cluster/replication.rs
+++ b/proxmox-api/src/generated/cluster/replication.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> ReplicationClient<T>

--- a/proxmox-api/src/generated/cluster/resources.rs
+++ b/proxmox-api/src/generated/cluster/resources.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self, params: GetParams) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &params).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &params).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/cluster/sdn.rs
+++ b/proxmox-api/src/generated/cluster/sdn.rs
@@ -30,7 +30,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> SdnClient<T>

--- a/proxmox-api/src/generated/cluster/sdn/controllers.rs
+++ b/proxmox-api/src/generated/cluster/sdn/controllers.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self, params: GetParams) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &params).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &params).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> ControllersClient<T>

--- a/proxmox-api/src/generated/cluster/sdn/dns.rs
+++ b/proxmox-api/src/generated/cluster/sdn/dns.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self, params: GetParams) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &params).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &params).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> DnsClient<T>

--- a/proxmox-api/src/generated/cluster/sdn/fabrics.rs
+++ b/proxmox-api/src/generated/cluster/sdn/fabrics.rs
@@ -25,7 +25,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/cluster/sdn/fabrics/fabric.rs
+++ b/proxmox-api/src/generated/cluster/sdn/fabrics/fabric.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self, params: GetParams) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &params).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &params).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> FabricClient<T>

--- a/proxmox-api/src/generated/cluster/sdn/fabrics/node.rs
+++ b/proxmox-api/src/generated/cluster/sdn/fabrics/node.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self, params: GetParams) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &params).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &params).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/cluster/sdn/fabrics/node/fabric_id.rs
+++ b/proxmox-api/src/generated/cluster/sdn/fabrics/node/fabric_id.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self, params: GetParams) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &params).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &params).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> FabricIdClient<T>

--- a/proxmox-api/src/generated/cluster/sdn/ipams.rs
+++ b/proxmox-api/src/generated/cluster/sdn/ipams.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self, params: GetParams) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &params).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &params).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> IpamsClient<T>

--- a/proxmox-api/src/generated/cluster/sdn/vnets.rs
+++ b/proxmox-api/src/generated/cluster/sdn/vnets.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self, params: GetParams) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &params).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &params).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> VnetsClient<T>

--- a/proxmox-api/src/generated/cluster/sdn/vnets/vnet/firewall.rs
+++ b/proxmox-api/src/generated/cluster/sdn/vnets/vnet/firewall.rs
@@ -24,7 +24,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]

--- a/proxmox-api/src/generated/cluster/sdn/vnets/vnet/firewall/rules.rs
+++ b/proxmox-api/src/generated/cluster/sdn/vnets/vnet/firewall/rules.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> RulesClient<T>

--- a/proxmox-api/src/generated/cluster/sdn/vnets/vnet/subnets.rs
+++ b/proxmox-api/src/generated/cluster/sdn/vnets/vnet/subnets.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self, params: GetParams) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &params).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &params).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> SubnetsClient<T>

--- a/proxmox-api/src/generated/cluster/sdn/zones.rs
+++ b/proxmox-api/src/generated/cluster/sdn/zones.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self, params: GetParams) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &params).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &params).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> ZonesClient<T>

--- a/proxmox-api/src/generated/cluster/status.rs
+++ b/proxmox-api/src/generated/cluster/status.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/cluster/tasks.rs
+++ b/proxmox-api/src/generated/cluster/tasks.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes.rs
+++ b/proxmox-api/src/generated/nodes.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node.rs
+++ b/proxmox-api/src/generated/nodes/node.rs
@@ -65,7 +65,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]

--- a/proxmox-api/src/generated/nodes/node/aplinfo.rs
+++ b/proxmox-api/src/generated/nodes/node/aplinfo.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> AplinfoClient<T>

--- a/proxmox-api/src/generated/nodes/node/apt.rs
+++ b/proxmox-api/src/generated/nodes/node/apt.rs
@@ -26,7 +26,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node/apt/update.rs
+++ b/proxmox-api/src/generated/nodes/node/apt/update.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> UpdateClient<T>

--- a/proxmox-api/src/generated/nodes/node/apt/versions.rs
+++ b/proxmox-api/src/generated/nodes/node/apt/versions.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node/capabilities.rs
+++ b/proxmox-api/src/generated/nodes/node/capabilities.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]

--- a/proxmox-api/src/generated/nodes/node/capabilities/qemu.rs
+++ b/proxmox-api/src/generated/nodes/node/capabilities/qemu.rs
@@ -26,7 +26,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]

--- a/proxmox-api/src/generated/nodes/node/capabilities/qemu/cpu.rs
+++ b/proxmox-api/src/generated/nodes/node/capabilities/qemu/cpu.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node/capabilities/qemu/cpu_flags.rs
+++ b/proxmox-api/src/generated/nodes/node/capabilities/qemu/cpu_flags.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node/capabilities/qemu/machines.rs
+++ b/proxmox-api/src/generated/nodes/node/capabilities/qemu/machines.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node/ceph.rs
+++ b/proxmox-api/src/generated/nodes/node/ceph.rs
@@ -38,7 +38,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]

--- a/proxmox-api/src/generated/nodes/node/ceph/cfg.rs
+++ b/proxmox-api/src/generated/nodes/node/ceph/cfg.rs
@@ -25,7 +25,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]

--- a/proxmox-api/src/generated/nodes/node/ceph/cfg/db.rs
+++ b/proxmox-api/src/generated/nodes/node/ceph/cfg/db.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node/ceph/fs.rs
+++ b/proxmox-api/src/generated/nodes/node/ceph/fs.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node/ceph/log.rs
+++ b/proxmox-api/src/generated/nodes/node/ceph/log.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self, params: GetParams) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &params).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &params).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node/ceph/mds.rs
+++ b/proxmox-api/src/generated/nodes/node/ceph/mds.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node/ceph/mgr.rs
+++ b/proxmox-api/src/generated/nodes/node/ceph/mgr.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node/ceph/mon.rs
+++ b/proxmox-api/src/generated/nodes/node/ceph/mon.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node/ceph/osd/osdid.rs
+++ b/proxmox-api/src/generated/nodes/node/ceph/osd/osdid.rs
@@ -38,7 +38,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]

--- a/proxmox-api/src/generated/nodes/node/ceph/pool.rs
+++ b/proxmox-api/src/generated/nodes/node/ceph/pool.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> PoolClient<T>

--- a/proxmox-api/src/generated/nodes/node/ceph/pool/name.rs
+++ b/proxmox-api/src/generated/nodes/node/ceph/pool/name.rs
@@ -34,7 +34,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> NameClient<T>

--- a/proxmox-api/src/generated/nodes/node/ceph/rules.rs
+++ b/proxmox-api/src/generated/nodes/node/ceph/rules.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node/certificates.rs
+++ b/proxmox-api/src/generated/nodes/node/certificates.rs
@@ -25,7 +25,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]

--- a/proxmox-api/src/generated/nodes/node/certificates/acme.rs
+++ b/proxmox-api/src/generated/nodes/node/certificates/acme.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]

--- a/proxmox-api/src/generated/nodes/node/certificates/info.rs
+++ b/proxmox-api/src/generated/nodes/node/certificates/info.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]

--- a/proxmox-api/src/generated/nodes/node/disks.rs
+++ b/proxmox-api/src/generated/nodes/node/disks.rs
@@ -30,7 +30,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]

--- a/proxmox-api/src/generated/nodes/node/disks/directory.rs
+++ b/proxmox-api/src/generated/nodes/node/disks/directory.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> DirectoryClient<T>

--- a/proxmox-api/src/generated/nodes/node/disks/list.rs
+++ b/proxmox-api/src/generated/nodes/node/disks/list.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self, params: GetParams) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &params).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &params).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node/disks/lvmthin.rs
+++ b/proxmox-api/src/generated/nodes/node/disks/lvmthin.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> LvmthinClient<T>

--- a/proxmox-api/src/generated/nodes/node/disks/zfs.rs
+++ b/proxmox-api/src/generated/nodes/node/disks/zfs.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> ZfsClient<T>

--- a/proxmox-api/src/generated/nodes/node/execute.rs
+++ b/proxmox-api/src/generated/nodes/node/execute.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn post(&self, params: PostParams) -> Result<Vec<PostOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.post(&path, &params).await
+        let optional_vec: Option<Vec<PostOutputItems>> = self.client.post(&path, &params).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]

--- a/proxmox-api/src/generated/nodes/node/firewall.rs
+++ b/proxmox-api/src/generated/nodes/node/firewall.rs
@@ -25,7 +25,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]

--- a/proxmox-api/src/generated/nodes/node/firewall/log.rs
+++ b/proxmox-api/src/generated/nodes/node/firewall/log.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self, params: GetParams) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &params).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &params).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node/firewall/rules.rs
+++ b/proxmox-api/src/generated/nodes/node/firewall/rules.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> RulesClient<T>

--- a/proxmox-api/src/generated/nodes/node/hardware.rs
+++ b/proxmox-api/src/generated/nodes/node/hardware.rs
@@ -24,7 +24,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node/hardware/pci.rs
+++ b/proxmox-api/src/generated/nodes/node/hardware/pci.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self, params: GetParams) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &params).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &params).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node/hardware/pci/pci_id_or_mapping.rs
+++ b/proxmox-api/src/generated/nodes/node/hardware/pci/pci_id_or_mapping.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node/hardware/pci/pci_id_or_mapping/mdev.rs
+++ b/proxmox-api/src/generated/nodes/node/hardware/pci/pci_id_or_mapping/mdev.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node/hardware/usb.rs
+++ b/proxmox-api/src/generated/nodes/node/hardware/usb.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node/journal.rs
+++ b/proxmox-api/src/generated/nodes/node/journal.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self, params: GetParams) -> Result<Vec<String>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &params).await
+        let optional_vec: Option<Vec<String>> = self.client.get(&path, &params).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]

--- a/proxmox-api/src/generated/nodes/node/lxc.rs
+++ b/proxmox-api/src/generated/nodes/node/lxc.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> LxcClient<T>

--- a/proxmox-api/src/generated/nodes/node/lxc/vmid.rs
+++ b/proxmox-api/src/generated/nodes/node/lxc/vmid.rs
@@ -54,7 +54,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]

--- a/proxmox-api/src/generated/nodes/node/lxc/vmid/firewall.rs
+++ b/proxmox-api/src/generated/nodes/node/lxc/vmid/firewall.rs
@@ -28,7 +28,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]

--- a/proxmox-api/src/generated/nodes/node/lxc/vmid/firewall/aliases.rs
+++ b/proxmox-api/src/generated/nodes/node/lxc/vmid/firewall/aliases.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> AliasesClient<T>

--- a/proxmox-api/src/generated/nodes/node/lxc/vmid/firewall/ipset.rs
+++ b/proxmox-api/src/generated/nodes/node/lxc/vmid/firewall/ipset.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> IpsetClient<T>

--- a/proxmox-api/src/generated/nodes/node/lxc/vmid/firewall/ipset/name.rs
+++ b/proxmox-api/src/generated/nodes/node/lxc/vmid/firewall/ipset/name.rs
@@ -34,7 +34,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> NameClient<T>

--- a/proxmox-api/src/generated/nodes/node/lxc/vmid/firewall/log.rs
+++ b/proxmox-api/src/generated/nodes/node/lxc/vmid/firewall/log.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self, params: GetParams) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &params).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &params).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node/lxc/vmid/firewall/refs.rs
+++ b/proxmox-api/src/generated/nodes/node/lxc/vmid/firewall/refs.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self, params: GetParams) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &params).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &params).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node/lxc/vmid/firewall/rules.rs
+++ b/proxmox-api/src/generated/nodes/node/lxc/vmid/firewall/rules.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> RulesClient<T>

--- a/proxmox-api/src/generated/nodes/node/lxc/vmid/interfaces.rs
+++ b/proxmox-api/src/generated/nodes/node/lxc/vmid/interfaces.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node/lxc/vmid/pending.rs
+++ b/proxmox-api/src/generated/nodes/node/lxc/vmid/pending.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node/lxc/vmid/rrddata.rs
+++ b/proxmox-api/src/generated/nodes/node/lxc/vmid/rrddata.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self, params: GetParams) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &params).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &params).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]

--- a/proxmox-api/src/generated/nodes/node/lxc/vmid/snapshot.rs
+++ b/proxmox-api/src/generated/nodes/node/lxc/vmid/snapshot.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> SnapshotClient<T>

--- a/proxmox-api/src/generated/nodes/node/lxc/vmid/snapshot/snapname.rs
+++ b/proxmox-api/src/generated/nodes/node/lxc/vmid/snapshot/snapname.rs
@@ -33,7 +33,8 @@ where
 {
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]

--- a/proxmox-api/src/generated/nodes/node/lxc/vmid/status.rs
+++ b/proxmox-api/src/generated/nodes/node/lxc/vmid/status.rs
@@ -29,7 +29,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node/netstat.rs
+++ b/proxmox-api/src/generated/nodes/node/netstat.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]

--- a/proxmox-api/src/generated/nodes/node/network.rs
+++ b/proxmox-api/src/generated/nodes/node/network.rs
@@ -34,7 +34,8 @@ where
     #[doc = ""]
     pub async fn get(&self, params: GetParams) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &params).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &params).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> NetworkClient<T>

--- a/proxmox-api/src/generated/nodes/node/qemu.rs
+++ b/proxmox-api/src/generated/nodes/node/qemu.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self, params: GetParams) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &params).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &params).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> QemuClient<T>

--- a/proxmox-api/src/generated/nodes/node/qemu/vmid.rs
+++ b/proxmox-api/src/generated/nodes/node/qemu/vmid.rs
@@ -59,7 +59,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]

--- a/proxmox-api/src/generated/nodes/node/qemu/vmid/agent.rs
+++ b/proxmox-api/src/generated/nodes/node/qemu/vmid/agent.rs
@@ -47,7 +47,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> AgentClient<T>

--- a/proxmox-api/src/generated/nodes/node/qemu/vmid/cloudinit.rs
+++ b/proxmox-api/src/generated/nodes/node/qemu/vmid/cloudinit.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> CloudinitClient<T>

--- a/proxmox-api/src/generated/nodes/node/qemu/vmid/firewall.rs
+++ b/proxmox-api/src/generated/nodes/node/qemu/vmid/firewall.rs
@@ -28,7 +28,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]

--- a/proxmox-api/src/generated/nodes/node/qemu/vmid/firewall/aliases.rs
+++ b/proxmox-api/src/generated/nodes/node/qemu/vmid/firewall/aliases.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> AliasesClient<T>

--- a/proxmox-api/src/generated/nodes/node/qemu/vmid/firewall/ipset.rs
+++ b/proxmox-api/src/generated/nodes/node/qemu/vmid/firewall/ipset.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> IpsetClient<T>

--- a/proxmox-api/src/generated/nodes/node/qemu/vmid/firewall/ipset/name.rs
+++ b/proxmox-api/src/generated/nodes/node/qemu/vmid/firewall/ipset/name.rs
@@ -34,7 +34,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> NameClient<T>

--- a/proxmox-api/src/generated/nodes/node/qemu/vmid/firewall/log.rs
+++ b/proxmox-api/src/generated/nodes/node/qemu/vmid/firewall/log.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self, params: GetParams) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &params).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &params).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node/qemu/vmid/firewall/refs.rs
+++ b/proxmox-api/src/generated/nodes/node/qemu/vmid/firewall/refs.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self, params: GetParams) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &params).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &params).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node/qemu/vmid/firewall/rules.rs
+++ b/proxmox-api/src/generated/nodes/node/qemu/vmid/firewall/rules.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> RulesClient<T>

--- a/proxmox-api/src/generated/nodes/node/qemu/vmid/pending.rs
+++ b/proxmox-api/src/generated/nodes/node/qemu/vmid/pending.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node/qemu/vmid/rrddata.rs
+++ b/proxmox-api/src/generated/nodes/node/qemu/vmid/rrddata.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self, params: GetParams) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &params).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &params).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]

--- a/proxmox-api/src/generated/nodes/node/qemu/vmid/snapshot.rs
+++ b/proxmox-api/src/generated/nodes/node/qemu/vmid/snapshot.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> SnapshotClient<T>

--- a/proxmox-api/src/generated/nodes/node/qemu/vmid/snapshot/snapname.rs
+++ b/proxmox-api/src/generated/nodes/node/qemu/vmid/snapshot/snapname.rs
@@ -33,7 +33,8 @@ where
 {
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]

--- a/proxmox-api/src/generated/nodes/node/qemu/vmid/status.rs
+++ b/proxmox-api/src/generated/nodes/node/qemu/vmid/status.rs
@@ -30,7 +30,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node/query_oci_repo_tags.rs
+++ b/proxmox-api/src/generated/nodes/node/query_oci_repo_tags.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self, params: GetParams) -> Result<Vec<String>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &params).await
+        let optional_vec: Option<Vec<String>> = self.client.get(&path, &params).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetParams {

--- a/proxmox-api/src/generated/nodes/node/replication.rs
+++ b/proxmox-api/src/generated/nodes/node/replication.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self, params: GetParams) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &params).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &params).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node/replication/id.rs
+++ b/proxmox-api/src/generated/nodes/node/replication/id.rs
@@ -25,7 +25,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]

--- a/proxmox-api/src/generated/nodes/node/replication/id/log.rs
+++ b/proxmox-api/src/generated/nodes/node/replication/id/log.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self, params: GetParams) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &params).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &params).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node/rrddata.rs
+++ b/proxmox-api/src/generated/nodes/node/rrddata.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self, params: GetParams) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &params).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &params).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]

--- a/proxmox-api/src/generated/nodes/node/scan.rs
+++ b/proxmox-api/src/generated/nodes/node/scan.rs
@@ -29,7 +29,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node/scan/cifs.rs
+++ b/proxmox-api/src/generated/nodes/node/scan/cifs.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self, params: GetParams) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &params).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &params).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node/scan/iscsi.rs
+++ b/proxmox-api/src/generated/nodes/node/scan/iscsi.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self, params: GetParams) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &params).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &params).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node/scan/lvm.rs
+++ b/proxmox-api/src/generated/nodes/node/scan/lvm.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node/scan/lvmthin.rs
+++ b/proxmox-api/src/generated/nodes/node/scan/lvmthin.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self, params: GetParams) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &params).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &params).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node/scan/nfs.rs
+++ b/proxmox-api/src/generated/nodes/node/scan/nfs.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self, params: GetParams) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &params).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &params).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node/scan/pbs.rs
+++ b/proxmox-api/src/generated/nodes/node/scan/pbs.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self, params: GetParams) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &params).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &params).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node/scan/zfs.rs
+++ b/proxmox-api/src/generated/nodes/node/scan/zfs.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node/sdn.rs
+++ b/proxmox-api/src/generated/nodes/node/sdn.rs
@@ -25,7 +25,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]

--- a/proxmox-api/src/generated/nodes/node/sdn/fabrics/fabric.rs
+++ b/proxmox-api/src/generated/nodes/node/sdn/fabrics/fabric.rs
@@ -25,7 +25,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node/sdn/fabrics/fabric/interfaces.rs
+++ b/proxmox-api/src/generated/nodes/node/sdn/fabrics/fabric/interfaces.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node/sdn/fabrics/fabric/neighbors.rs
+++ b/proxmox-api/src/generated/nodes/node/sdn/fabrics/fabric/neighbors.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node/sdn/fabrics/fabric/routes.rs
+++ b/proxmox-api/src/generated/nodes/node/sdn/fabrics/fabric/routes.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node/sdn/vnets/vnet.rs
+++ b/proxmox-api/src/generated/nodes/node/sdn/vnets/vnet.rs
@@ -21,7 +21,8 @@ where
 {
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node/sdn/vnets/vnet/mac_vrf.rs
+++ b/proxmox-api/src/generated/nodes/node/sdn/vnets/vnet/mac_vrf.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node/sdn/zones.rs
+++ b/proxmox-api/src/generated/nodes/node/sdn/zones.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node/sdn/zones/zone.rs
+++ b/proxmox-api/src/generated/nodes/node/sdn/zones/zone.rs
@@ -25,7 +25,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node/sdn/zones/zone/bridges.rs
+++ b/proxmox-api/src/generated/nodes/node/sdn/zones/zone/bridges.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node/sdn/zones/zone/content.rs
+++ b/proxmox-api/src/generated/nodes/node/sdn/zones/zone/content.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node/sdn/zones/zone/ip_vrf.rs
+++ b/proxmox-api/src/generated/nodes/node/sdn/zones/zone/ip_vrf.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node/services.rs
+++ b/proxmox-api/src/generated/nodes/node/services.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node/services/service.rs
+++ b/proxmox-api/src/generated/nodes/node/services/service.rs
@@ -27,7 +27,8 @@ where
     #[doc = ""]
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node/storage.rs
+++ b/proxmox-api/src/generated/nodes/node/storage.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self, params: GetParams) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &params).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &params).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl FormatsGetOutputItemsFormats {

--- a/proxmox-api/src/generated/nodes/node/storage/storage.rs
+++ b/proxmox-api/src/generated/nodes/node/storage/storage.rs
@@ -30,7 +30,8 @@ where
 {
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node/storage/storage/content.rs
+++ b/proxmox-api/src/generated/nodes/node/storage/storage/content.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self, params: GetParams) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &params).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &params).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> ContentClient<T>

--- a/proxmox-api/src/generated/nodes/node/storage/storage/file_restore/list.rs
+++ b/proxmox-api/src/generated/nodes/node/storage/storage/file_restore/list.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self, params: GetParams) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &params).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &params).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node/storage/storage/prunebackups.rs
+++ b/proxmox-api/src/generated/nodes/node/storage/storage/prunebackups.rs
@@ -33,7 +33,8 @@ where
     #[doc = ""]
     pub async fn get(&self, params: GetParams) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &params).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &params).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]

--- a/proxmox-api/src/generated/nodes/node/storage/storage/rrddata.rs
+++ b/proxmox-api/src/generated/nodes/node/storage/storage/rrddata.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self, params: GetParams) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &params).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &params).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]

--- a/proxmox-api/src/generated/nodes/node/syslog.rs
+++ b/proxmox-api/src/generated/nodes/node/syslog.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self, params: GetParams) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &params).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &params).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node/tasks.rs
+++ b/proxmox-api/src/generated/nodes/node/tasks.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self, params: GetParams) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &params).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &params).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/nodes/node/tasks/upid.rs
+++ b/proxmox-api/src/generated/nodes/node/tasks/upid.rs
@@ -33,7 +33,8 @@ where
 {
     pub async fn get(&self) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &()).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &()).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]

--- a/proxmox-api/src/generated/nodes/node/tasks/upid/log.rs
+++ b/proxmox-api/src/generated/nodes/node/tasks/upid/log.rs
@@ -22,7 +22,8 @@ where
     #[doc = ""]
     pub async fn get(&self, params: GetParams) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &params).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &params).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl GetOutputItems {

--- a/proxmox-api/src/generated/pools.rs
+++ b/proxmox-api/src/generated/pools.rs
@@ -34,7 +34,8 @@ where
     #[doc = ""]
     pub async fn get(&self, params: GetParams) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &params).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &params).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> PoolsClient<T>

--- a/proxmox-api/src/generated/storage.rs
+++ b/proxmox-api/src/generated/storage.rs
@@ -23,7 +23,8 @@ where
     #[doc = ""]
     pub async fn get(&self, params: GetParams) -> Result<Vec<GetOutputItems>, T::Error> {
         let path = self.path.to_string();
-        self.client.get(&path, &params).await
+        let optional_vec: Option<Vec<GetOutputItems>> = self.client.get(&path, &params).await?;
+        Ok(optional_vec.unwrap_or_default())
     }
 }
 impl<T> StorageClient<T>


### PR DESCRIPTION
Originally discovered by @glmdev:

  PVE sometimes returns {"data":null} for array endpoints that have
  no data which causes an UnknownError to be raised.

Make all array-returning functions interpret 'null' as 'Vec::new()' by deserializing as an Option instead.

Closes #46