### PR TITLE
Fix generation of return types for implicit "object" types

### DIFF
--- a/generator/src/raw/returns.rs
+++ b/generator/src/raw/returns.rs
@@ -9,7 +9,7 @@ pub struct Returns<'a> {
     #[serde(borrow, flatten, default, skip_serializing_if = "Option::is_none")]
     pub ty: Option<Type<'a>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub link: Option<Link<'a>>,
+    pub links: Option<Link<'a>>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/generator/src/raw/ty.rs
+++ b/generator/src/raw/ty.rs
@@ -102,6 +102,67 @@ pub struct Type<'a> {
         skip_serializing_if = "Option::is_none"
     )]
     pub key_alias: Option<Cow<'a, str>>,
+    #[serde(borrow, default, skip_serializing_if = "Option::is_none")]
+    pub properties: Option<BTreeMap<Cow<'a, str>, Type<'a>>>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        rename = "additionalProperties"
+    )]
+    pub additional_properties: Option<IntOrTy<'a>>,
+}
+
+fn build_object_output<'a>(
+    properties: &Option<BTreeMap<Cow<'a, str>, Type<'a>>>,
+    additional_properties: &Option<IntOrTy<'a>>,
+    field_name: &str,
+    struct_suffix: &str,
+) -> Option<Output> {
+    let mut final_output = Output::new();
+
+    let field_name_ident = crate::name_to_ident(field_name);
+    let suffix = crate::name_to_ident(struct_suffix);
+    let struct_name = format!("{field_name_ident}{suffix}");
+
+    let additional_int_or_ty = additional_properties.as_ref().cloned().unwrap_or_default();
+    let (additional_props, ext) = additional_int_or_ty.as_additional_properties(struct_suffix);
+    final_output.module_defs.extend(ext);
+
+    if let Some(props) = properties {
+        let fields: Vec<_> = props
+            .iter()
+            .filter_map(|(original_name, ty)| {
+                let field_name = crate::name_to_ident(original_name);
+                let output = ty.type_def(&field_name, &format!("{struct_suffix}{field_name}"))?;
+                let inner = output.def.as_ref()?.clone();
+                final_output.absorb(output);
+
+                let doc = ty.doc();
+                let optional = ty.optional.get();
+
+                let field = FieldDef::new(original_name.to_string(), inner, optional, doc);
+
+                if let Some(numbered_items) = field.numbered_items() {
+                    final_output
+                        .module_defs
+                        .push(TypeDef::NumberedItems(Box::new(numbered_items.clone())));
+                }
+
+                Some(field)
+            })
+            .collect();
+
+        let def = TypeDef::new_struct(struct_name, fields, additional_props);
+        final_output.def = Some(def);
+
+        Some(final_output)
+    } else if !additional_props.is_none() {
+        let def = TypeDef::new_struct(struct_name, Vec::new(), additional_props);
+        final_output.def = Some(def);
+        Some(final_output)
+    } else {
+        None
+    }
 }
 
 impl Type<'_> {
@@ -209,61 +270,25 @@ impl Type<'_> {
 
                     return Some(output);
                 }
-                TypeKind::Object {
-                    properties,
-                    additional_properties,
-                } => {
-                    let mut final_output = Output::new();
-
-                    let field_name = crate::name_to_ident(field_name);
-                    let suffix = crate::name_to_ident(struct_suffix);
-                    let struct_name = format!("{field_name}{suffix}");
-                    let mut all_external = Vec::new();
-
-                    let (additional_props, ext) =
-                        additional_properties.as_additional_properties(struct_suffix);
-
-                    all_external.extend(ext);
-
-                    if let Some(props) = properties {
-                        let fields: Vec<_> = props
-                            .iter()
-                            .filter_map(|(original_name, ty)| {
-                                let field_name = crate::name_to_ident(original_name);
-                                let output = ty.type_def(
-                                    &field_name,
-                                    &format!("{struct_suffix}{field_name}"),
-                                )?;
-                                let inner = output.def.as_ref()?.clone();
-                                final_output.absorb(output);
-
-                                let doc = ty.doc();
-                                let optional = ty.optional.get();
-
-                                let field =
-                                    FieldDef::new(original_name.to_string(), inner, optional, doc);
-
-                                if let Some(numbered_items) = field.numbered_items() {
-                                    final_output.module_defs.push(TypeDef::NumberedItems(
-                                        Box::new(numbered_items.clone()),
-                                    ));
-                                }
-
-                                Some(field)
-                            })
-                            .collect();
-
-                        let def = TypeDef::new_struct(struct_name, fields, additional_props);
-                        final_output.def = Some(def);
-
-                        return Some(final_output);
-                    } else if !additional_props.is_none() {
-                        TypeDef::new_struct(struct_name, Vec::new(), additional_props)
-                    } else {
-                        return None;
-                    }
+                TypeKind::Object => {
+                    // explicit "object" return type variant
+                    return build_object_output(
+                        &self.properties,
+                        &self.additional_properties,
+                        field_name,
+                        struct_suffix,
+                    );
                 }
             }
+        } else if self.properties.is_some() || self.additional_properties.is_some() {
+            // implicit "object" return type variant
+            log::debug!("encountered implicit object");
+            return build_object_output(
+                &self.properties,
+                &self.additional_properties,
+                field_name,
+                struct_suffix,
+            );
         } else {
             return None;
         };
@@ -331,6 +356,7 @@ impl Default for IntOrTy<'_> {
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 #[serde(tag = "type", rename_all = "kebab-case")]
+#[serde(bound(deserialize = "'de: 'a"))]
 pub enum TypeKind<'a> {
     String {
         #[serde(rename = "maxLength", default, skip_serializing_if = "Option::is_none")]
@@ -401,14 +427,11 @@ pub enum TypeKind<'a> {
     Array {
         items: Box<Type<'a>>,
     },
-    Object {
-        #[serde(borrow, default, skip_serializing_if = "Option::is_none")]
-        properties: Option<BTreeMap<Cow<'a, str>, Type<'a>>>,
-        #[serde(
-            default,
-            skip_serializing_if = "IntOrTy::is_unset",
-            rename = "additionalProperties"
-        )]
-        additional_properties: IntOrTy<'a>,
-    },
+    /// "properties" and "additional_properties", which would normally
+    /// be here, have been lifted into the parent `Type<'a>` to handle
+    /// cases where there is no "type" property specified.
+    ///
+    /// This variant is effectively now just a marker that the schema
+    /// contained an explicit `"type" : "object"`.
+    Object,
 }

--- a/generator/src/tracker.rs
+++ b/generator/src/tracker.rs
@@ -56,25 +56,18 @@ impl FormatTracker {
             self.analyze_format(format);
         }
 
-        if let Some(kind) = &ty.ty {
-            match kind {
-                TypeKind::Array { items } => self.analyze_type(items),
-                TypeKind::Object {
-                    properties,
-                    additional_properties,
-                } => {
-                    if let Some(properties) = properties {
-                        for ty in properties.values() {
-                            self.analyze_type(ty);
-                        }
-                    }
+        if let Some(TypeKind::Array { items }) = &ty.ty {
+            self.analyze_type(items);
+        }
 
-                    if let IntOrTy::Ty(ty) = additional_properties {
-                        self.analyze_type(ty);
-                    }
-                }
-                _ => {}
+        if let Some(properties) = &ty.properties {
+            for inner in properties.values() {
+                self.analyze_type(inner);
             }
+        }
+
+        if let Some(IntOrTy::Ty(inner)) = &ty.additional_properties {
+            self.analyze_type(inner);
         }
     }
 

--- a/proxmox-api/src/generated/access/openid/login.rs
+++ b/proxmox-api/src/generated/access/openid/login.rs
@@ -20,10 +20,52 @@ where
 {
     #[doc = "Verify OpenID authorization code and create a ticket."]
     #[doc = ""]
-    pub async fn post(&self, params: PostParams) -> Result<(), T::Error> {
+    pub async fn post(&self, params: PostParams) -> Result<PostOutput, T::Error> {
         let path = self.path.to_string();
         self.client.post(&path, &params).await
     }
+}
+#[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]
+pub struct CapPostOutputCap {
+    #[serde(
+        flatten,
+        default,
+        skip_serializing_if = "::std::collections::HashMap::is_empty"
+    )]
+    pub additional_properties: ::std::collections::HashMap<String, ::serde_json::Value>,
+}
+impl PostOutput {
+    pub fn new(
+        csrfpreventiontoken: String,
+        cap: CapPostOutputCap,
+        ticket: String,
+        username: String,
+    ) -> Self {
+        Self {
+            csrfpreventiontoken,
+            cap,
+            ticket,
+            username,
+            clustername: ::std::default::Default::default(),
+            additional_properties: ::std::default::Default::default(),
+        }
+    }
+}
+#[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize)]
+pub struct PostOutput {
+    #[serde(rename = "CSRFPreventionToken")]
+    pub csrfpreventiontoken: String,
+    pub cap: CapPostOutputCap,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub clustername: Option<String>,
+    pub ticket: String,
+    pub username: String,
+    #[serde(
+        flatten,
+        default,
+        skip_serializing_if = "::std::collections::HashMap::is_empty"
+    )]
+    pub additional_properties: ::std::collections::HashMap<String, ::serde_json::Value>,
 }
 impl PostParams {
     pub fn new(code: CodeStr, redirect_url: RedirectUrlStr, state: StateStr) -> Self {

--- a/proxmox-api/src/generated/cluster/ceph/metadata.rs
+++ b/proxmox-api/src/generated/cluster/ceph/metadata.rs
@@ -31,12 +31,14 @@ impl GetOutput {
         mgr: MgrGetOutputMgr,
         mon: MonGetOutputMon,
         node: NodeGetOutputNode,
+        osd: OsdGetOutputOsd,
     ) -> Self {
         Self {
             mds,
             mgr,
             mon,
             node,
+            osd,
             additional_properties: ::std::default::Default::default(),
         }
     }
@@ -55,6 +57,9 @@ pub struct GetOutput {
     #[doc = "Ceph version installed on the nodes."]
     #[doc = ""]
     pub node: NodeGetOutputNode,
+    #[doc = "OSDs configured in the cluster and their properties."]
+    #[doc = ""]
+    pub osd: OsdGetOutputOsd,
     #[serde(
         flatten,
         default,
@@ -268,6 +273,95 @@ pub struct IdGetOutputMonId {
     )]
     pub additional_properties: ::std::collections::HashMap<String, ::serde_json::Value>,
 }
+impl IdGetOutputOsdId {
+    pub fn new(
+        back_addr: String,
+        ceph_release: String,
+        ceph_version: String,
+        ceph_version_short: String,
+        device_id: String,
+        front_addr: String,
+        hostname: String,
+        id: i64,
+        mem_swap_kb: i64,
+        mem_total_kb: i64,
+        osd_data: String,
+        osd_objectstore: String,
+    ) -> Self {
+        Self {
+            back_addr,
+            ceph_release,
+            ceph_version,
+            ceph_version_short,
+            device_id,
+            front_addr,
+            hostname,
+            id,
+            mem_swap_kb,
+            mem_total_kb,
+            osd_data,
+            osd_objectstore,
+            additional_properties: ::std::default::Default::default(),
+        }
+    }
+}
+#[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize)]
+pub struct IdGetOutputOsdId {
+    #[doc = "Bind addresses and ports for backend inter OSD traffic."]
+    #[doc = ""]
+    pub back_addr: String,
+    #[doc = "Ceph release codename currently used."]
+    #[doc = ""]
+    pub ceph_release: String,
+    #[doc = "Version info currently used by the service."]
+    #[doc = ""]
+    pub ceph_version: String,
+    #[doc = "Short version (numerical) info currently used by the service."]
+    #[doc = ""]
+    pub ceph_version_short: String,
+    #[doc = "Devices used by the OSD."]
+    #[doc = ""]
+    pub device_id: String,
+    #[doc = "Bind addresses and ports for frontend traffic to OSDs."]
+    #[doc = ""]
+    pub front_addr: String,
+    #[doc = "Hostname on which the service is running."]
+    #[doc = ""]
+    pub hostname: String,
+    #[serde(
+        serialize_with = "crate::types::serialize_int",
+        deserialize_with = "crate::types::deserialize_int"
+    )]
+    #[doc = "OSD ID."]
+    #[doc = ""]
+    pub id: i64,
+    #[serde(
+        serialize_with = "crate::types::serialize_int",
+        deserialize_with = "crate::types::deserialize_int"
+    )]
+    #[doc = "Memory of the service currently in swap."]
+    #[doc = ""]
+    pub mem_swap_kb: i64,
+    #[serde(
+        serialize_with = "crate::types::serialize_int",
+        deserialize_with = "crate::types::deserialize_int"
+    )]
+    #[doc = "Memory consumption of the service."]
+    #[doc = ""]
+    pub mem_total_kb: i64,
+    #[doc = "Path to the OSD data directory."]
+    #[doc = ""]
+    pub osd_data: String,
+    #[doc = "OSD objectstore type."]
+    #[doc = ""]
+    pub osd_objectstore: String,
+    #[serde(
+        flatten,
+        default,
+        skip_serializing_if = "::std::collections::HashMap::is_empty"
+    )]
+    pub additional_properties: ::std::collections::HashMap<String, ::serde_json::Value>,
+}
 impl MdsGetOutputMds {
     pub fn new(_id: IdGetOutputMdsId) -> Self {
         Self {
@@ -367,6 +461,27 @@ pub struct NodeGetOutputNodeNode {
     #[doc = "Version info."]
     #[doc = ""]
     pub version: VersionGetOutputNodeNodeVersion,
+    #[serde(
+        flatten,
+        default,
+        skip_serializing_if = "::std::collections::HashMap::is_empty"
+    )]
+    pub additional_properties: ::std::collections::HashMap<String, ::serde_json::Value>,
+}
+impl OsdGetOutputOsd {
+    pub fn new(_id: IdGetOutputOsdId) -> Self {
+        Self {
+            _id,
+            additional_properties: ::std::default::Default::default(),
+        }
+    }
+}
+#[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize)]
+pub struct OsdGetOutputOsd {
+    #[serde(rename = "{id}")]
+    #[doc = "Useful properties are listed, but not the full list."]
+    #[doc = ""]
+    pub _id: IdGetOutputOsdId,
     #[serde(
         flatten,
         default,

--- a/proxmox-api/src/generated/cluster/sdn/controllers/controller.rs
+++ b/proxmox-api/src/generated/cluster/sdn/controllers/controller.rs
@@ -31,7 +31,7 @@ where
 {
     #[doc = "Read sdn controller configuration."]
     #[doc = ""]
-    pub async fn get(&self, params: GetParams) -> Result<(), T::Error> {
+    pub async fn get(&self, params: GetParams) -> Result<GetOutput, T::Error> {
         let path = self.path.to_string();
         self.client.get(&path, &params).await
     }
@@ -61,6 +61,113 @@ pub struct DeleteParams {
     )]
     pub additional_properties: ::std::collections::HashMap<String, ::serde_json::Value>,
 }
+impl GetOutput {
+    pub fn new(controller: String, ty: Type) -> Self {
+        Self {
+            controller,
+            ty,
+            asn: ::std::default::Default::default(),
+            bgp_multipath_as_relax: ::std::default::Default::default(),
+            digest: ::std::default::Default::default(),
+            ebgp: ::std::default::Default::default(),
+            ebgp_multihop: ::std::default::Default::default(),
+            isis_domain: ::std::default::Default::default(),
+            isis_ifaces: ::std::default::Default::default(),
+            isis_net: ::std::default::Default::default(),
+            loopback: ::std::default::Default::default(),
+            node: ::std::default::Default::default(),
+            peers: ::std::default::Default::default(),
+            pending: ::std::default::Default::default(),
+            state: ::std::default::Default::default(),
+            additional_properties: ::std::default::Default::default(),
+        }
+    }
+}
+#[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize)]
+pub struct GetOutput {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "The local ASN of the controller. BGP & EVPN only."]
+    #[doc = ""]
+    pub asn: Option<AsnInt>,
+    #[serde(rename = "bgp-multipath-as-relax")]
+    #[serde(
+        serialize_with = "crate::types::serialize_bool_optional",
+        deserialize_with = "crate::types::deserialize_bool_optional"
+    )]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "Consider different AS paths of equal length for multipath computation. BGP only."]
+    #[doc = ""]
+    pub bgp_multipath_as_relax: Option<bool>,
+    #[doc = "Name of the controller."]
+    #[doc = ""]
+    pub controller: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "Digest of the controller section."]
+    #[doc = ""]
+    pub digest: Option<String>,
+    #[serde(
+        serialize_with = "crate::types::serialize_bool_optional",
+        deserialize_with = "crate::types::deserialize_bool_optional"
+    )]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "Enable eBGP (remote-as external). BGP only."]
+    #[doc = ""]
+    pub ebgp: Option<bool>,
+    #[serde(rename = "ebgp-multihop")]
+    #[serde(
+        serialize_with = "crate::types::serialize_int_optional",
+        deserialize_with = "crate::types::deserialize_int_optional"
+    )]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "Set maximum amount of hops for eBGP peers. Needs ebgp set to 1. BGP only."]
+    #[doc = ""]
+    pub ebgp_multihop: Option<i64>,
+    #[serde(rename = "isis-domain")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "Name of the IS-IS domain. IS-IS only."]
+    #[doc = ""]
+    pub isis_domain: Option<String>,
+    #[serde(rename = "isis-ifaces")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "Comma-separated list of interfaces where IS-IS should be active. IS-IS only."]
+    #[doc = ""]
+    pub isis_ifaces: Option<String>,
+    #[serde(rename = "isis-net")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "Network Entity title for this node in the IS-IS network. IS-IS only."]
+    #[doc = ""]
+    pub isis_net: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "Name of the loopback/dummy interface that provides the Router-IP. BGP only."]
+    #[doc = ""]
+    pub loopback: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "Node(s) where this controller is active."]
+    #[doc = ""]
+    pub node: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "Comma-separated list of the peers IP addresses."]
+    #[doc = ""]
+    pub peers: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "Changes that have not yet been applied to the running configuration."]
+    #[doc = ""]
+    pub pending: Option<PendingGetOutputPending>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "State of the SDN configuration object."]
+    #[doc = ""]
+    pub state: Option<State>,
+    #[serde(rename = "type")]
+    #[doc = "Type of the controller"]
+    #[doc = ""]
+    pub ty: Type,
+    #[serde(
+        flatten,
+        default,
+        skip_serializing_if = "::std::collections::HashMap::is_empty"
+    )]
+    pub additional_properties: ::std::collections::HashMap<String, ::serde_json::Value>,
+}
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]
 pub struct GetParams {
     #[serde(
@@ -79,6 +186,72 @@ pub struct GetParams {
     #[doc = "Display running config."]
     #[doc = ""]
     pub running: Option<bool>,
+    #[serde(
+        flatten,
+        default,
+        skip_serializing_if = "::std::collections::HashMap::is_empty"
+    )]
+    pub additional_properties: ::std::collections::HashMap<String, ::serde_json::Value>,
+}
+#[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]
+pub struct PendingGetOutputPending {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "The local ASN of the controller. BGP & EVPN only."]
+    #[doc = ""]
+    pub asn: Option<AsnInt>,
+    #[serde(rename = "bgp-multipath-as-relax")]
+    #[serde(
+        serialize_with = "crate::types::serialize_bool_optional",
+        deserialize_with = "crate::types::deserialize_bool_optional"
+    )]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "Consider different AS paths of equal length for multipath computation. BGP only."]
+    #[doc = ""]
+    pub bgp_multipath_as_relax: Option<bool>,
+    #[serde(
+        serialize_with = "crate::types::serialize_bool_optional",
+        deserialize_with = "crate::types::deserialize_bool_optional"
+    )]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "Enable eBGP (remote-as external). BGP only."]
+    #[doc = ""]
+    pub ebgp: Option<bool>,
+    #[serde(rename = "ebgp-multihop")]
+    #[serde(
+        serialize_with = "crate::types::serialize_int_optional",
+        deserialize_with = "crate::types::deserialize_int_optional"
+    )]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "Set maximum amount of hops for eBGP peers. Needs ebgp set to 1. BGP only."]
+    #[doc = ""]
+    pub ebgp_multihop: Option<i64>,
+    #[serde(rename = "isis-domain")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "Name of the IS-IS domain. IS-IS only."]
+    #[doc = ""]
+    pub isis_domain: Option<String>,
+    #[serde(rename = "isis-ifaces")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "Comma-separated list of interfaces where IS-IS should be active. IS-IS only."]
+    #[doc = ""]
+    pub isis_ifaces: Option<String>,
+    #[serde(rename = "isis-net")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "Network Entity title for this node in the IS-IS network. IS-IS only."]
+    #[doc = ""]
+    pub isis_net: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "Name of the loopback/dummy interface that provides the Router-IP. BGP only."]
+    #[doc = ""]
+    pub loopback: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "Node(s) where this controller is active."]
+    #[doc = ""]
+    pub node: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "Comma-separated list of the peers IP addresses."]
+    #[doc = ""]
+    pub peers: Option<String>,
     #[serde(
         flatten,
         default,
@@ -168,6 +341,53 @@ pub struct PutParams {
         skip_serializing_if = "::std::collections::HashMap::is_empty"
     )]
     pub additional_properties: ::std::collections::HashMap<String, ::serde_json::Value>,
+}
+#[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, PartialEq)]
+#[doc = "State of the SDN configuration object."]
+#[doc = ""]
+pub enum State {
+    #[serde(rename = "changed")]
+    Changed,
+    #[serde(rename = "deleted")]
+    Deleted,
+    #[serde(rename = "new")]
+    New,
+}
+impl TryFrom<&str> for State {
+    type Error = String;
+    fn try_from(value: &str) -> Result<Self, <Self as TryFrom<&str>>::Error> {
+        match value {
+            "changed" => Ok(Self::Changed),
+            "deleted" => Ok(Self::Deleted),
+            "new" => Ok(Self::New),
+            v => Err(format!("Unknown variant {v}")),
+        }
+    }
+}
+#[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, PartialEq)]
+#[doc = "Type of the controller"]
+#[doc = ""]
+pub enum Type {
+    #[serde(rename = "bgp")]
+    Bgp,
+    #[serde(rename = "evpn")]
+    Evpn,
+    #[serde(rename = "faucet")]
+    Faucet,
+    #[serde(rename = "isis")]
+    Isis,
+}
+impl TryFrom<&str> for Type {
+    type Error = String;
+    fn try_from(value: &str) -> Result<Self, <Self as TryFrom<&str>>::Error> {
+        match value {
+            "bgp" => Ok(Self::Bgp),
+            "evpn" => Ok(Self::Evpn),
+            "faucet" => Ok(Self::Faucet),
+            "isis" => Ok(Self::Isis),
+            v => Err(format!("Unknown variant {v}")),
+        }
+    }
 }
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
 pub struct AsnInt(i128);

--- a/proxmox-api/src/generated/cluster/sdn/fabrics/node/fabric_id/node_id.rs
+++ b/proxmox-api/src/generated/cluster/sdn/fabrics/node/fabric_id/node_id.rs
@@ -31,7 +31,7 @@ where
 {
     #[doc = "Get a node"]
     #[doc = ""]
-    pub async fn get(&self) -> Result<(), T::Error> {
+    pub async fn get(&self) -> Result<GetOutput, T::Error> {
         let path = self.path.to_string();
         self.client.get(&path, &()).await
     }
@@ -46,6 +46,55 @@ where
         let path = self.path.to_string();
         self.client.put(&path, &params).await
     }
+}
+impl GetOutput {
+    pub fn new(fabric_id: String, node_id: String, protocol: Protocol) -> Self {
+        Self {
+            fabric_id,
+            node_id,
+            protocol,
+            digest: ::std::default::Default::default(),
+            ip: ::std::default::Default::default(),
+            ip6: ::std::default::Default::default(),
+            lock_token: ::std::default::Default::default(),
+            additional_properties: ::std::default::Default::default(),
+        }
+    }
+}
+#[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize)]
+pub struct GetOutput {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "Prevent changes if current configuration file has a different digest. This can be used to prevent concurrent modifications."]
+    #[doc = ""]
+    pub digest: Option<DigestStr>,
+    #[doc = "Identifier for SDN fabrics"]
+    #[doc = ""]
+    pub fabric_id: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "IPv4 address for this node"]
+    #[doc = ""]
+    pub ip: Option<::std::net::Ipv4Addr>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "IPv6 address for this node"]
+    #[doc = ""]
+    pub ip6: Option<::std::net::Ipv6Addr>,
+    #[serde(rename = "lock-token")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "the token for unlocking the global SDN configuration"]
+    #[doc = ""]
+    pub lock_token: Option<String>,
+    #[doc = "Identifier for nodes in an SDN fabric"]
+    #[doc = ""]
+    pub node_id: String,
+    #[doc = "Type of configuration entry in an SDN Fabric section config"]
+    #[doc = ""]
+    pub protocol: Protocol,
+    #[serde(
+        flatten,
+        default,
+        skip_serializing_if = "::std::collections::HashMap::is_empty"
+    )]
+    pub additional_properties: ::std::collections::HashMap<String, ::serde_json::Value>,
 }
 impl PutParams {
     pub fn new(protocol: Protocol) -> Self {

--- a/proxmox-api/src/generated/cluster/sdn/vnets/vnet.rs
+++ b/proxmox-api/src/generated/cluster/sdn/vnets/vnet.rs
@@ -34,7 +34,7 @@ where
 {
     #[doc = "Read sdn vnet configuration."]
     #[doc = ""]
-    pub async fn get(&self, params: GetParams) -> Result<(), T::Error> {
+    pub async fn get(&self, params: GetParams) -> Result<GetOutput, T::Error> {
         let path = self.path.to_string();
         self.client.get(&path, &params).await
     }
@@ -64,6 +64,80 @@ pub struct DeleteParams {
     )]
     pub additional_properties: ::std::collections::HashMap<String, ::serde_json::Value>,
 }
+impl GetOutput {
+    pub fn new(ty: Type, vnet: String) -> Self {
+        Self {
+            ty,
+            vnet,
+            alias: ::std::default::Default::default(),
+            digest: ::std::default::Default::default(),
+            isolate_ports: ::std::default::Default::default(),
+            pending: ::std::default::Default::default(),
+            state: ::std::default::Default::default(),
+            tag: ::std::default::Default::default(),
+            vlanaware: ::std::default::Default::default(),
+            zone: ::std::default::Default::default(),
+            additional_properties: ::std::default::Default::default(),
+        }
+    }
+}
+#[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize)]
+pub struct GetOutput {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "Alias name of the VNet."]
+    #[doc = ""]
+    pub alias: Option<AliasStr>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "Digest of the VNet section."]
+    #[doc = ""]
+    pub digest: Option<String>,
+    #[serde(rename = "isolate-ports")]
+    #[serde(
+        serialize_with = "crate::types::serialize_bool_optional",
+        deserialize_with = "crate::types::deserialize_bool_optional"
+    )]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "If true, sets the isolated property for all interfaces on the bridge of this VNet."]
+    #[doc = ""]
+    pub isolate_ports: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "Changes that have not yet been applied to the running configuration."]
+    #[doc = ""]
+    pub pending: Option<PendingGetOutputPending>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "State of the SDN configuration object."]
+    #[doc = ""]
+    pub state: Option<State>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "VLAN Tag (for VLAN or QinQ zones) or VXLAN VNI (for VXLAN or EVPN zones)."]
+    #[doc = ""]
+    pub tag: Option<TagInt>,
+    #[serde(rename = "type")]
+    #[doc = "Type of the VNet."]
+    #[doc = ""]
+    pub ty: Type,
+    #[serde(
+        serialize_with = "crate::types::serialize_bool_optional",
+        deserialize_with = "crate::types::deserialize_bool_optional"
+    )]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "Allow VLANs to pass through this VNet."]
+    #[doc = ""]
+    pub vlanaware: Option<bool>,
+    #[doc = "Name of the VNet."]
+    #[doc = ""]
+    pub vnet: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "Name of the zone this VNet belongs to."]
+    #[doc = ""]
+    pub zone: Option<String>,
+    #[serde(
+        flatten,
+        default,
+        skip_serializing_if = "::std::collections::HashMap::is_empty"
+    )]
+    pub additional_properties: ::std::collections::HashMap<String, ::serde_json::Value>,
+}
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]
 pub struct GetParams {
     #[serde(
@@ -82,6 +156,44 @@ pub struct GetParams {
     #[doc = "Display running config."]
     #[doc = ""]
     pub running: Option<bool>,
+    #[serde(
+        flatten,
+        default,
+        skip_serializing_if = "::std::collections::HashMap::is_empty"
+    )]
+    pub additional_properties: ::std::collections::HashMap<String, ::serde_json::Value>,
+}
+#[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]
+pub struct PendingGetOutputPending {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "Alias name of the VNet."]
+    #[doc = ""]
+    pub alias: Option<AliasStr>,
+    #[serde(rename = "isolate-ports")]
+    #[serde(
+        serialize_with = "crate::types::serialize_bool_optional",
+        deserialize_with = "crate::types::deserialize_bool_optional"
+    )]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "If true, sets the isolated property for all interfaces on the bridge of this VNet."]
+    #[doc = ""]
+    pub isolate_ports: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "VLAN Tag (for VLAN or QinQ zones) or VXLAN VNI (for VXLAN or EVPN zones)."]
+    #[doc = ""]
+    pub tag: Option<TagInt>,
+    #[serde(
+        serialize_with = "crate::types::serialize_bool_optional",
+        deserialize_with = "crate::types::deserialize_bool_optional"
+    )]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "Allow VLANs to pass through this VNet."]
+    #[doc = ""]
+    pub vlanaware: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "Name of the zone this VNet belongs to."]
+    #[doc = ""]
+    pub zone: Option<String>,
     #[serde(
         flatten,
         default,
@@ -139,6 +251,44 @@ pub struct PutParams {
         skip_serializing_if = "::std::collections::HashMap::is_empty"
     )]
     pub additional_properties: ::std::collections::HashMap<String, ::serde_json::Value>,
+}
+#[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, PartialEq)]
+#[doc = "State of the SDN configuration object."]
+#[doc = ""]
+pub enum State {
+    #[serde(rename = "changed")]
+    Changed,
+    #[serde(rename = "deleted")]
+    Deleted,
+    #[serde(rename = "new")]
+    New,
+}
+impl TryFrom<&str> for State {
+    type Error = String;
+    fn try_from(value: &str) -> Result<Self, <Self as TryFrom<&str>>::Error> {
+        match value {
+            "changed" => Ok(Self::Changed),
+            "deleted" => Ok(Self::Deleted),
+            "new" => Ok(Self::New),
+            v => Err(format!("Unknown variant {v}")),
+        }
+    }
+}
+#[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, PartialEq)]
+#[doc = "Type of the VNet."]
+#[doc = ""]
+pub enum Type {
+    #[serde(rename = "vnet")]
+    Vnet,
+}
+impl TryFrom<&str> for Type {
+    type Error = String;
+    fn try_from(value: &str) -> Result<Self, <Self as TryFrom<&str>>::Error> {
+        match value {
+            "vnet" => Ok(Self::Vnet),
+            v => Err(format!("Unknown variant {v}")),
+        }
+    }
 }
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
 pub struct TagInt(i128);

--- a/proxmox-api/src/generated/cluster/sdn/zones/zone.rs
+++ b/proxmox-api/src/generated/cluster/sdn/zones/zone.rs
@@ -31,7 +31,7 @@ where
 {
     #[doc = "Read sdn zone configuration."]
     #[doc = ""]
-    pub async fn get(&self, params: GetParams) -> Result<(), T::Error> {
+    pub async fn get(&self, params: GetParams) -> Result<GetOutput, T::Error> {
         let path = self.path.to_string();
         self.client.get(&path, &params).await
     }
@@ -61,6 +61,189 @@ pub struct DeleteParams {
     )]
     pub additional_properties: ::std::collections::HashMap<String, ::serde_json::Value>,
 }
+impl GetOutput {
+    pub fn new(ty: Type, zone: String) -> Self {
+        Self {
+            ty,
+            zone,
+            advertise_subnets: ::std::default::Default::default(),
+            bridge: ::std::default::Default::default(),
+            bridge_disable_mac_learning: ::std::default::Default::default(),
+            controller: ::std::default::Default::default(),
+            dhcp: ::std::default::Default::default(),
+            digest: ::std::default::Default::default(),
+            disable_arp_nd_suppression: ::std::default::Default::default(),
+            dns: ::std::default::Default::default(),
+            dnszone: ::std::default::Default::default(),
+            exitnodes: ::std::default::Default::default(),
+            exitnodes_local_routing: ::std::default::Default::default(),
+            exitnodes_primary: ::std::default::Default::default(),
+            ipam: ::std::default::Default::default(),
+            mac: ::std::default::Default::default(),
+            mtu: ::std::default::Default::default(),
+            nodes: ::std::default::Default::default(),
+            peers: ::std::default::Default::default(),
+            pending: ::std::default::Default::default(),
+            reversedns: ::std::default::Default::default(),
+            rt_import: ::std::default::Default::default(),
+            state: ::std::default::Default::default(),
+            tag: ::std::default::Default::default(),
+            vlan_protocol: ::std::default::Default::default(),
+            vrf_vxlan: ::std::default::Default::default(),
+            vxlan_port: ::std::default::Default::default(),
+            additional_properties: ::std::default::Default::default(),
+        }
+    }
+}
+#[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize)]
+pub struct GetOutput {
+    #[serde(rename = "advertise-subnets")]
+    #[serde(
+        serialize_with = "crate::types::serialize_bool_optional",
+        deserialize_with = "crate::types::deserialize_bool_optional"
+    )]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "Advertise IP prefixes (Type-5 routes) instead of MAC/IP pairs (Type-2 routes). EVPN zone only."]
+    #[doc = ""]
+    pub advertise_subnets: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "the bridge for which VLANs should be managed. VLAN & QinQ zone only."]
+    #[doc = ""]
+    pub bridge: Option<String>,
+    #[serde(rename = "bridge-disable-mac-learning")]
+    #[serde(
+        serialize_with = "crate::types::serialize_bool_optional",
+        deserialize_with = "crate::types::deserialize_bool_optional"
+    )]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "Disable auto mac learning. VLAN zone only."]
+    #[doc = ""]
+    pub bridge_disable_mac_learning: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "ID of the controller for this zone. EVPN zone only."]
+    #[doc = ""]
+    pub controller: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "Name of DHCP server backend for this zone."]
+    #[doc = ""]
+    pub dhcp: Option<Dhcp>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "Digest of the controller section."]
+    #[doc = ""]
+    pub digest: Option<String>,
+    #[serde(rename = "disable-arp-nd-suppression")]
+    #[serde(
+        serialize_with = "crate::types::serialize_bool_optional",
+        deserialize_with = "crate::types::deserialize_bool_optional"
+    )]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "Suppress IPv4 ARP && IPv6 Neighbour Discovery messages. EVPN zone only."]
+    #[doc = ""]
+    pub disable_arp_nd_suppression: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "ID of the DNS server for this zone."]
+    #[doc = ""]
+    pub dns: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "Domain name for this zone."]
+    #[doc = ""]
+    pub dnszone: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "List of PVE Nodes that should act as exit node for this zone. EVPN zone only."]
+    #[doc = ""]
+    pub exitnodes: Option<String>,
+    #[serde(rename = "exitnodes-local-routing")]
+    #[serde(
+        serialize_with = "crate::types::serialize_bool_optional",
+        deserialize_with = "crate::types::deserialize_bool_optional"
+    )]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "Create routes on the exit nodes, so they can connect to EVPN guests. EVPN zone only."]
+    #[doc = ""]
+    pub exitnodes_local_routing: Option<bool>,
+    #[serde(rename = "exitnodes-primary")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "Force traffic through this exitnode first. EVPN zone only."]
+    #[doc = ""]
+    pub exitnodes_primary: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "ID of the IPAM for this zone."]
+    #[doc = ""]
+    pub ipam: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "MAC address of the anycast router for this zone."]
+    #[doc = ""]
+    pub mac: Option<String>,
+    #[serde(
+        serialize_with = "crate::types::serialize_int_optional",
+        deserialize_with = "crate::types::deserialize_int_optional"
+    )]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "MTU of the zone, will be used for the created VNet bridges."]
+    #[doc = ""]
+    pub mtu: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "Nodes where this zone should be created."]
+    #[doc = ""]
+    pub nodes: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "Comma-separated list of peers, that are part of the VXLAN zone. Usually the IPs of the nodes. VXLAN zone only."]
+    #[doc = ""]
+    pub peers: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "Changes that have not yet been applied to the running configuration."]
+    #[doc = ""]
+    pub pending: Option<PendingGetOutputPending>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "ID of the reverse DNS server for this zone."]
+    #[doc = ""]
+    pub reversedns: Option<String>,
+    #[serde(rename = "rt-import")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "Route-Targets that should be imported into the VRF of this zone via BGP. EVPN zone only."]
+    #[doc = ""]
+    pub rt_import: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "State of the SDN configuration object."]
+    #[doc = ""]
+    pub state: Option<State>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "Service-VLAN Tag (outer VLAN). QinQ zone only"]
+    #[doc = ""]
+    pub tag: Option<u64>,
+    #[serde(rename = "type")]
+    #[doc = "Type of the zone."]
+    #[doc = ""]
+    pub ty: Type,
+    #[serde(rename = "vlan-protocol")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "VLAN protocol for the creation of the QinQ zone. QinQ zone only."]
+    #[doc = ""]
+    pub vlan_protocol: Option<VlanProtocol>,
+    #[serde(rename = "vrf-vxlan")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "VNI for the zone VRF. EVPN zone only."]
+    #[doc = ""]
+    pub vrf_vxlan: Option<VrfVxlanInt>,
+    #[serde(rename = "vxlan-port")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "UDP port that should be used for the VXLAN tunnel (default 4789). VXLAN zone only."]
+    #[doc = ""]
+    pub vxlan_port: Option<VxlanPortInt>,
+    #[doc = "Name of the zone."]
+    #[doc = ""]
+    pub zone: String,
+    #[serde(
+        flatten,
+        default,
+        skip_serializing_if = "::std::collections::HashMap::is_empty"
+    )]
+    pub additional_properties: ::std::collections::HashMap<String, ::serde_json::Value>,
+}
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]
 pub struct GetParams {
     #[serde(
@@ -79,6 +262,136 @@ pub struct GetParams {
     #[doc = "Display running config."]
     #[doc = ""]
     pub running: Option<bool>,
+    #[serde(
+        flatten,
+        default,
+        skip_serializing_if = "::std::collections::HashMap::is_empty"
+    )]
+    pub additional_properties: ::std::collections::HashMap<String, ::serde_json::Value>,
+}
+#[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]
+pub struct PendingGetOutputPending {
+    #[serde(rename = "advertise-subnets")]
+    #[serde(
+        serialize_with = "crate::types::serialize_bool_optional",
+        deserialize_with = "crate::types::deserialize_bool_optional"
+    )]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "Advertise IP prefixes (Type-5 routes) instead of MAC/IP pairs (Type-2 routes). EVPN zone only."]
+    #[doc = ""]
+    pub advertise_subnets: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "the bridge for which VLANs should be managed. VLAN & QinQ zone only."]
+    #[doc = ""]
+    pub bridge: Option<String>,
+    #[serde(rename = "bridge-disable-mac-learning")]
+    #[serde(
+        serialize_with = "crate::types::serialize_bool_optional",
+        deserialize_with = "crate::types::deserialize_bool_optional"
+    )]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "Disable auto mac learning. VLAN zone only."]
+    #[doc = ""]
+    pub bridge_disable_mac_learning: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "ID of the controller for this zone. EVPN zone only."]
+    #[doc = ""]
+    pub controller: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "Name of DHCP server backend for this zone."]
+    #[doc = ""]
+    pub dhcp: Option<Dhcp>,
+    #[serde(rename = "disable-arp-nd-suppression")]
+    #[serde(
+        serialize_with = "crate::types::serialize_bool_optional",
+        deserialize_with = "crate::types::deserialize_bool_optional"
+    )]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "Suppress IPv4 ARP && IPv6 Neighbour Discovery messages. EVPN zone only."]
+    #[doc = ""]
+    pub disable_arp_nd_suppression: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "ID of the DNS server for this zone."]
+    #[doc = ""]
+    pub dns: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "Domain name for this zone."]
+    #[doc = ""]
+    pub dnszone: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "List of PVE Nodes that should act as exit node for this zone. EVPN zone only."]
+    #[doc = ""]
+    pub exitnodes: Option<String>,
+    #[serde(rename = "exitnodes-local-routing")]
+    #[serde(
+        serialize_with = "crate::types::serialize_bool_optional",
+        deserialize_with = "crate::types::deserialize_bool_optional"
+    )]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "Create routes on the exit nodes, so they can connect to EVPN guests. EVPN zone only."]
+    #[doc = ""]
+    pub exitnodes_local_routing: Option<bool>,
+    #[serde(rename = "exitnodes-primary")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "Force traffic through this exitnode first. EVPN zone only."]
+    #[doc = ""]
+    pub exitnodes_primary: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "ID of the IPAM for this zone."]
+    #[doc = ""]
+    pub ipam: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "MAC address of the anycast router for this zone."]
+    #[doc = ""]
+    pub mac: Option<String>,
+    #[serde(
+        serialize_with = "crate::types::serialize_int_optional",
+        deserialize_with = "crate::types::deserialize_int_optional"
+    )]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "MTU of the zone, will be used for the created VNet bridges."]
+    #[doc = ""]
+    pub mtu: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "Nodes where this zone should be created."]
+    #[doc = ""]
+    pub nodes: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "Comma-separated list of peers, that are part of the VXLAN zone. Usually the IPs of the nodes. VXLAN zone only."]
+    #[doc = ""]
+    pub peers: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "ID of the reverse DNS server for this zone."]
+    #[doc = ""]
+    pub reversedns: Option<String>,
+    #[serde(rename = "rt-import")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "Route-Targets that should be imported into the VRF of this zone via BGP. EVPN zone only."]
+    #[doc = ""]
+    pub rt_import: Option<String>,
+    #[serde(
+        serialize_with = "crate::types::serialize_unsigned_int_optional",
+        deserialize_with = "crate::types::deserialize_unsigned_int_optional"
+    )]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "Service-VLAN Tag (outer VLAN). QinQ zone only"]
+    #[doc = ""]
+    pub tag: Option<u64>,
+    #[serde(rename = "vlan-protocol")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "VLAN protocol for the creation of the QinQ zone. QinQ zone only."]
+    #[doc = ""]
+    pub vlan_protocol: Option<VlanProtocol>,
+    #[serde(rename = "vrf-vxlan")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "VNI for the zone VRF. EVPN zone only."]
+    #[doc = ""]
+    pub vrf_vxlan: Option<VrfVxlanInt>,
+    #[serde(rename = "vxlan-port")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "UDP port that should be used for the VXLAN tunnel (default 4789). VXLAN zone only."]
+    #[doc = ""]
+    pub vxlan_port: Option<VxlanPortInt>,
     #[serde(
         flatten,
         default,
@@ -243,7 +556,7 @@ pub struct PutParams {
     pub additional_properties: ::std::collections::HashMap<String, ::serde_json::Value>,
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, PartialEq)]
-#[doc = "Type of the DHCP backend for this zone"]
+#[doc = "Name of DHCP server backend for this zone."]
 #[doc = ""]
 pub enum Dhcp {
     #[serde(rename = "dnsmasq")]
@@ -258,8 +571,61 @@ impl TryFrom<&str> for Dhcp {
         }
     }
 }
+#[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, PartialEq)]
+#[doc = "State of the SDN configuration object."]
+#[doc = ""]
+pub enum State {
+    #[serde(rename = "changed")]
+    Changed,
+    #[serde(rename = "deleted")]
+    Deleted,
+    #[serde(rename = "new")]
+    New,
+}
+impl TryFrom<&str> for State {
+    type Error = String;
+    fn try_from(value: &str) -> Result<Self, <Self as TryFrom<&str>>::Error> {
+        match value {
+            "changed" => Ok(Self::Changed),
+            "deleted" => Ok(Self::Deleted),
+            "new" => Ok(Self::New),
+            v => Err(format!("Unknown variant {v}")),
+        }
+    }
+}
+#[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, PartialEq)]
+#[doc = "Type of the zone."]
+#[doc = ""]
+pub enum Type {
+    #[serde(rename = "evpn")]
+    Evpn,
+    #[serde(rename = "faucet")]
+    Faucet,
+    #[serde(rename = "qinq")]
+    Qinq,
+    #[serde(rename = "simple")]
+    Simple,
+    #[serde(rename = "vlan")]
+    Vlan,
+    #[serde(rename = "vxlan")]
+    Vxlan,
+}
+impl TryFrom<&str> for Type {
+    type Error = String;
+    fn try_from(value: &str) -> Result<Self, <Self as TryFrom<&str>>::Error> {
+        match value {
+            "evpn" => Ok(Self::Evpn),
+            "faucet" => Ok(Self::Faucet),
+            "qinq" => Ok(Self::Qinq),
+            "simple" => Ok(Self::Simple),
+            "vlan" => Ok(Self::Vlan),
+            "vxlan" => Ok(Self::Vxlan),
+            v => Err(format!("Unknown variant {v}")),
+        }
+    }
+}
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, PartialEq, Default)]
-#[doc = "Which VLAN protocol should be used for the creation of the QinQ zone."]
+#[doc = "VLAN protocol for the creation of the QinQ zone. QinQ zone only."]
 #[doc = ""]
 pub enum VlanProtocol {
     #[serde(rename = "802.1ad")]

--- a/proxmox-api/src/generated/nodes/node/lxc/vmid/mtunnel.rs
+++ b/proxmox-api/src/generated/nodes/node/lxc/vmid/mtunnel.rs
@@ -20,10 +20,25 @@ where
 {
     #[doc = "Migration tunnel endpoint - only for internal use by CT migration."]
     #[doc = ""]
-    pub async fn post(&self, params: PostParams) -> Result<(), T::Error> {
+    pub async fn post(&self, params: PostParams) -> Result<PostOutput, T::Error> {
         let path = self.path.to_string();
         self.client.post(&path, &params).await
     }
+}
+impl PostOutput {
+    pub fn new(socket: String, ticket: String, upid: String) -> Self {
+        Self {
+            socket,
+            ticket,
+            upid,
+        }
+    }
+}
+#[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize)]
+pub struct PostOutput {
+    pub socket: String,
+    pub ticket: String,
+    pub upid: String,
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]
 pub struct PostParams {

--- a/proxmox-api/src/generated/nodes/node/lxc/vmid/spiceproxy.rs
+++ b/proxmox-api/src/generated/nodes/node/lxc/vmid/spiceproxy.rs
@@ -20,10 +20,42 @@ where
 {
     #[doc = "Returns a SPICE configuration to connect to the CT."]
     #[doc = ""]
-    pub async fn post(&self, params: PostParams) -> Result<(), T::Error> {
+    pub async fn post(&self, params: PostParams) -> Result<PostOutput, T::Error> {
         let path = self.path.to_string();
         self.client.post(&path, &params).await
     }
+}
+impl PostOutput {
+    pub fn new(host: String, password: String, proxy: String, tls_port: i64, ty: String) -> Self {
+        Self {
+            host,
+            password,
+            proxy,
+            tls_port,
+            ty,
+            additional_properties: ::std::default::Default::default(),
+        }
+    }
+}
+#[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize)]
+pub struct PostOutput {
+    pub host: String,
+    pub password: String,
+    pub proxy: String,
+    #[serde(rename = "tls-port")]
+    #[serde(
+        serialize_with = "crate::types::serialize_int",
+        deserialize_with = "crate::types::deserialize_int"
+    )]
+    pub tls_port: i64,
+    #[serde(rename = "type")]
+    pub ty: String,
+    #[serde(
+        flatten,
+        default,
+        skip_serializing_if = "::std::collections::HashMap::is_empty"
+    )]
+    pub additional_properties: ::std::collections::HashMap<String, ::serde_json::Value>,
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]
 pub struct PostParams {

--- a/proxmox-api/src/generated/nodes/node/lxc/vmid/termproxy.rs
+++ b/proxmox-api/src/generated/nodes/node/lxc/vmid/termproxy.rs
@@ -20,8 +20,29 @@ where
 {
     #[doc = "Creates a TCP proxy connection."]
     #[doc = ""]
-    pub async fn post(&self) -> Result<(), T::Error> {
+    pub async fn post(&self) -> Result<PostOutput, T::Error> {
         let path = self.path.to_string();
         self.client.post(&path, &()).await
     }
+}
+impl PostOutput {
+    pub fn new(port: i64, ticket: String, upid: String, user: String) -> Self {
+        Self {
+            port,
+            ticket,
+            upid,
+            user,
+        }
+    }
+}
+#[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize)]
+pub struct PostOutput {
+    #[serde(
+        serialize_with = "crate::types::serialize_int",
+        deserialize_with = "crate::types::deserialize_int"
+    )]
+    pub port: i64,
+    pub ticket: String,
+    pub upid: String,
+    pub user: String,
 }

--- a/proxmox-api/src/generated/nodes/node/lxc/vmid/vncproxy.rs
+++ b/proxmox-api/src/generated/nodes/node/lxc/vmid/vncproxy.rs
@@ -20,10 +20,33 @@ where
 {
     #[doc = "Creates a TCP VNC proxy connections."]
     #[doc = ""]
-    pub async fn post(&self, params: PostParams) -> Result<(), T::Error> {
+    pub async fn post(&self, params: PostParams) -> Result<PostOutput, T::Error> {
         let path = self.path.to_string();
         self.client.post(&path, &params).await
     }
+}
+impl PostOutput {
+    pub fn new(cert: String, port: i64, ticket: String, upid: String, user: String) -> Self {
+        Self {
+            cert,
+            port,
+            ticket,
+            upid,
+            user,
+        }
+    }
+}
+#[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize)]
+pub struct PostOutput {
+    pub cert: String,
+    #[serde(
+        serialize_with = "crate::types::serialize_int",
+        deserialize_with = "crate::types::deserialize_int"
+    )]
+    pub port: i64,
+    pub ticket: String,
+    pub upid: String,
+    pub user: String,
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]
 pub struct PostParams {

--- a/proxmox-api/src/generated/nodes/node/qemu/vmid/mtunnel.rs
+++ b/proxmox-api/src/generated/nodes/node/qemu/vmid/mtunnel.rs
@@ -20,10 +20,25 @@ where
 {
     #[doc = "Migration tunnel endpoint - only for internal use by VM migration."]
     #[doc = ""]
-    pub async fn post(&self, params: PostParams) -> Result<(), T::Error> {
+    pub async fn post(&self, params: PostParams) -> Result<PostOutput, T::Error> {
         let path = self.path.to_string();
         self.client.post(&path, &params).await
     }
+}
+impl PostOutput {
+    pub fn new(socket: String, ticket: String, upid: String) -> Self {
+        Self {
+            socket,
+            ticket,
+            upid,
+        }
+    }
+}
+#[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize)]
+pub struct PostOutput {
+    pub socket: String,
+    pub ticket: String,
+    pub upid: String,
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]
 pub struct PostParams {

--- a/proxmox-api/src/generated/nodes/node/qemu/vmid/spiceproxy.rs
+++ b/proxmox-api/src/generated/nodes/node/qemu/vmid/spiceproxy.rs
@@ -20,10 +20,42 @@ where
 {
     #[doc = "Returns a SPICE configuration to connect to the VM."]
     #[doc = ""]
-    pub async fn post(&self, params: PostParams) -> Result<(), T::Error> {
+    pub async fn post(&self, params: PostParams) -> Result<PostOutput, T::Error> {
         let path = self.path.to_string();
         self.client.post(&path, &params).await
     }
+}
+impl PostOutput {
+    pub fn new(host: String, password: String, proxy: String, tls_port: i64, ty: String) -> Self {
+        Self {
+            host,
+            password,
+            proxy,
+            tls_port,
+            ty,
+            additional_properties: ::std::default::Default::default(),
+        }
+    }
+}
+#[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize)]
+pub struct PostOutput {
+    pub host: String,
+    pub password: String,
+    pub proxy: String,
+    #[serde(rename = "tls-port")]
+    #[serde(
+        serialize_with = "crate::types::serialize_int",
+        deserialize_with = "crate::types::deserialize_int"
+    )]
+    pub tls_port: i64,
+    #[serde(rename = "type")]
+    pub ty: String,
+    #[serde(
+        flatten,
+        default,
+        skip_serializing_if = "::std::collections::HashMap::is_empty"
+    )]
+    pub additional_properties: ::std::collections::HashMap<String, ::serde_json::Value>,
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]
 pub struct PostParams {

--- a/proxmox-api/src/generated/nodes/node/qemu/vmid/termproxy.rs
+++ b/proxmox-api/src/generated/nodes/node/qemu/vmid/termproxy.rs
@@ -20,10 +20,31 @@ where
 {
     #[doc = "Creates a TCP proxy connections."]
     #[doc = ""]
-    pub async fn post(&self, params: PostParams) -> Result<(), T::Error> {
+    pub async fn post(&self, params: PostParams) -> Result<PostOutput, T::Error> {
         let path = self.path.to_string();
         self.client.post(&path, &params).await
     }
+}
+impl PostOutput {
+    pub fn new(port: i64, ticket: String, upid: String, user: String) -> Self {
+        Self {
+            port,
+            ticket,
+            upid,
+            user,
+        }
+    }
+}
+#[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize)]
+pub struct PostOutput {
+    #[serde(
+        serialize_with = "crate::types::serialize_int",
+        deserialize_with = "crate::types::deserialize_int"
+    )]
+    pub port: i64,
+    pub ticket: String,
+    pub upid: String,
+    pub user: String,
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]
 pub struct PostParams {

--- a/proxmox-api/src/generated/nodes/node/qemu/vmid/vncproxy.rs
+++ b/proxmox-api/src/generated/nodes/node/qemu/vmid/vncproxy.rs
@@ -20,10 +20,38 @@ where
 {
     #[doc = "Creates a TCP VNC proxy connections."]
     #[doc = ""]
-    pub async fn post(&self, params: PostParams) -> Result<(), T::Error> {
+    pub async fn post(&self, params: PostParams) -> Result<PostOutput, T::Error> {
         let path = self.path.to_string();
         self.client.post(&path, &params).await
     }
+}
+impl PostOutput {
+    pub fn new(cert: String, port: i64, ticket: String, upid: String, user: String) -> Self {
+        Self {
+            cert,
+            port,
+            ticket,
+            upid,
+            user,
+            password: ::std::default::Default::default(),
+        }
+    }
+}
+#[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize)]
+pub struct PostOutput {
+    pub cert: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[doc = "Returned if requested with 'generate-password' param. Consists of printable ASCII characters ('!' .. '~')."]
+    #[doc = ""]
+    pub password: Option<String>,
+    #[serde(
+        serialize_with = "crate::types::serialize_int",
+        deserialize_with = "crate::types::deserialize_int"
+    )]
+    pub port: i64,
+    pub ticket: String,
+    pub upid: String,
+    pub user: String,
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]
 pub struct PostParams {

--- a/proxmox-api/src/generated/nodes/node/spiceshell.rs
+++ b/proxmox-api/src/generated/nodes/node/spiceshell.rs
@@ -20,10 +20,42 @@ where
 {
     #[doc = "Creates a SPICE shell."]
     #[doc = ""]
-    pub async fn post(&self, params: PostParams) -> Result<(), T::Error> {
+    pub async fn post(&self, params: PostParams) -> Result<PostOutput, T::Error> {
         let path = self.path.to_string();
         self.client.post(&path, &params).await
     }
+}
+impl PostOutput {
+    pub fn new(host: String, password: String, proxy: String, tls_port: i64, ty: String) -> Self {
+        Self {
+            host,
+            password,
+            proxy,
+            tls_port,
+            ty,
+            additional_properties: ::std::default::Default::default(),
+        }
+    }
+}
+#[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize)]
+pub struct PostOutput {
+    pub host: String,
+    pub password: String,
+    pub proxy: String,
+    #[serde(rename = "tls-port")]
+    #[serde(
+        serialize_with = "crate::types::serialize_int",
+        deserialize_with = "crate::types::deserialize_int"
+    )]
+    pub tls_port: i64,
+    #[serde(rename = "type")]
+    pub ty: String,
+    #[serde(
+        flatten,
+        default,
+        skip_serializing_if = "::std::collections::HashMap::is_empty"
+    )]
+    pub additional_properties: ::std::collections::HashMap<String, ::serde_json::Value>,
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]
 pub struct PostParams {

--- a/proxmox-api/src/generated/nodes/node/termproxy.rs
+++ b/proxmox-api/src/generated/nodes/node/termproxy.rs
@@ -20,10 +20,39 @@ where
 {
     #[doc = "Creates a VNC Shell proxy."]
     #[doc = ""]
-    pub async fn post(&self, params: PostParams) -> Result<(), T::Error> {
+    pub async fn post(&self, params: PostParams) -> Result<PostOutput, T::Error> {
         let path = self.path.to_string();
         self.client.post(&path, &params).await
     }
+}
+impl PostOutput {
+    pub fn new(port: i64, ticket: String, upid: String, user: String) -> Self {
+        Self {
+            port,
+            ticket,
+            upid,
+            user,
+        }
+    }
+}
+#[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize)]
+pub struct PostOutput {
+    #[serde(
+        serialize_with = "crate::types::serialize_int",
+        deserialize_with = "crate::types::deserialize_int"
+    )]
+    #[doc = "port used to bind termproxy to."]
+    #[doc = ""]
+    pub port: i64,
+    #[doc = "VNC ticket used to verify websocket connection."]
+    #[doc = ""]
+    pub ticket: String,
+    #[doc = "UPID for termproxy worker task."]
+    #[doc = ""]
+    pub upid: String,
+    #[doc = "user/token that generated the VNC ticket in `ticket`."]
+    #[doc = ""]
+    pub user: String,
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]
 pub struct PostParams {

--- a/proxmox-api/src/generated/nodes/node/vncshell.rs
+++ b/proxmox-api/src/generated/nodes/node/vncshell.rs
@@ -20,10 +20,33 @@ where
 {
     #[doc = "Creates a VNC Shell proxy."]
     #[doc = ""]
-    pub async fn post(&self, params: PostParams) -> Result<(), T::Error> {
+    pub async fn post(&self, params: PostParams) -> Result<PostOutput, T::Error> {
         let path = self.path.to_string();
         self.client.post(&path, &params).await
     }
+}
+impl PostOutput {
+    pub fn new(cert: String, port: i64, ticket: String, upid: String, user: String) -> Self {
+        Self {
+            cert,
+            port,
+            ticket,
+            upid,
+            user,
+        }
+    }
+}
+#[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize)]
+pub struct PostOutput {
+    pub cert: String,
+    #[serde(
+        serialize_with = "crate::types::serialize_int",
+        deserialize_with = "crate::types::deserialize_int"
+    )]
+    pub port: i64,
+    pub ticket: String,
+    pub upid: String,
+    pub user: String,
 }
 #[derive(Clone, Debug, :: serde :: Serialize, :: serde :: Deserialize, Default)]
 pub struct PostParams {


### PR DESCRIPTION
Fixes #68.

Uses the same approach as for `Parameters` by lifting the `properties` and `additional_properties` fields to the parent struct.