### PR TITLE
feat!: implement upload to storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -747,6 +747,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1025,6 +1041,7 @@ dependencies = [
  "base64",
  "bytes",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -1033,6 +1050,7 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -1523,6 +1541,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/generator/src/generator/mod.rs
+++ b/generator/src/generator/mod.rs
@@ -129,8 +129,7 @@ impl Generator {
                 let fn_name = Ident::new(&fn_name_str, quote!().span());
 
                 // Detect upload endpoints so we can generate a specific signature for them.
-                let is_file_upload = fn_name_str == "post"
-                    && matches!(segment, PathElement::Literal(s) if s == "upload");
+                let is_file_upload = fn_name_str == "post" && info.name == "upload";
 
                 let (signature, defer_signature) = if let Some(TypeDef::Struct(strt)) = &parameters
                 {
@@ -138,7 +137,7 @@ impl Generator {
                     if is_file_upload {
                         (
                             quote!(&self, params: #name, data: Vec<u8>),
-                            quote!(&path, &params, data),
+                            quote!(&path, params, data),
                         )
                     } else {
                         (quote!(&self, params: #name), quote!(&path, &params))

--- a/generator/src/generator/mod.rs
+++ b/generator/src/generator/mod.rs
@@ -128,10 +128,21 @@ impl Generator {
                 let fn_name_str = method.to_ascii_lowercase();
                 let fn_name = Ident::new(&fn_name_str, quote!().span());
 
+                // Detect upload endpoints so we can generate a specific signature for them.
+                let is_file_upload = fn_name_str == "post"
+                    && matches!(segment, PathElement::Literal(s) if s == "upload");
+
                 let (signature, defer_signature) = if let Some(TypeDef::Struct(strt)) = &parameters
                 {
                     let name = Ident::new(&strt.name(), quote! {}.span());
-                    (quote!(&self, params: #name), quote!(&path, &params))
+                    if is_file_upload {
+                        (
+                            quote!(&self, params: #name, data: Vec<u8>),
+                            quote!(&path, &params, data),
+                        )
+                    } else {
+                        (quote!(&self, params: #name), quote!(&path, &params))
+                    }
                 } else {
                     (quote!(&self), quote!(&path, &()))
                 };
@@ -147,7 +158,11 @@ impl Generator {
 
                         let (_, name) = def.as_field_ty(ret.optional.get());
 
-                        let call = Self::to_call(def.primitive(), &fn_name, defer_signature);
+                        let call = if is_file_upload {
+                            quote!(self.client.upload(#defer_signature).await)
+                        } else {
+                            Self::to_call(def.primitive(), &fn_name, defer_signature)
+                        };
 
                         let call = if matches!(def, TypeDef::Array(_)) {
                             quote! {

--- a/proxmox-api/Cargo.toml
+++ b/proxmox-api/Cargo.toml
@@ -44,7 +44,7 @@ serde_json = { version = "1.0.150", default-features = false, features = ["std"]
 serde_urlencoded = { optional = true, version = "0.7.1" }
 log = { optional = true, version = "0.4.30", default-features = false, features = ["std"] }
 parking_lot = { optional = true, version = "0.12.5" }
-reqwest = { optional = true, version = "0.13", default-features = false, features = ["default-tls", "query"] }
+reqwest = { optional = true, version = "0.13", default-features = false, features = ["default-tls", "query", "multipart"] }
 clap = { optional = true, version = "4.6.1", default-features = false, features = ["std", "help", "usage", "error-context", "color", "derive", "env"] }
 pretty_env_logger = { optional = true, version = "0.5.0" }
 regex = "1.12.3"

--- a/proxmox-api/src/client.rs
+++ b/proxmox-api/src/client.rs
@@ -1,5 +1,9 @@
 use serde::{Serialize, de::DeserializeOwned};
 
+pub trait AsFilename {
+    fn as_filename(&self) -> String;
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Method {
     Post,
@@ -26,11 +30,11 @@ pub trait Client: Clone {
     fn upload<B, R>(
         &self,
         path: &str,
-        body: &B,
+        body: B,
         data: Vec<u8>,
     ) -> impl Future<Output = Result<R, Self::Error>>
     where
-        B: Serialize,
+        B: IntoIterator<Item = (String, String)> + AsFilename,
         R: DeserializeOwned;
 
     /// Transmit an authenticated request to a Proxmox VE API endpoint
@@ -115,11 +119,11 @@ where
     fn upload<B, R>(
         &self,
         path: &str,
-        body: &B,
+        body: B,
         data: Vec<u8>,
     ) -> impl Future<Output = Result<R, Self::Error>>
     where
-        B: Serialize,
+        B: IntoIterator<Item = (String, String)> + AsFilename,
         R: DeserializeOwned,
     {
         T::upload(self, path, body, data)

--- a/proxmox-api/src/client.rs
+++ b/proxmox-api/src/client.rs
@@ -22,6 +22,17 @@ impl std::fmt::Display for Method {
 pub trait Client: Clone {
     type Error: core::fmt::Debug;
 
+    /// Upload a file to a Proxmox VE API endpoint using multipart/form-data.
+    fn upload<B, R>(
+        &self,
+        path: &str,
+        body: &B,
+        data: Vec<u8>,
+    ) -> impl Future<Output = Result<R, Self::Error>>
+    where
+        B: Serialize,
+        R: DeserializeOwned;
+
     /// Transmit an authenticated request to a Proxmox VE API endpoint
     /// using the provided method, path, body, and query.
     fn request_with_body_and_query<B, Q, R>(
@@ -100,6 +111,19 @@ where
     T: Client,
 {
     type Error = <T as Client>::Error;
+
+    fn upload<B, R>(
+        &self,
+        path: &str,
+        body: &B,
+        data: Vec<u8>,
+    ) -> impl Future<Output = Result<R, Self::Error>>
+    where
+        B: Serialize,
+        R: DeserializeOwned,
+    {
+        T::upload(self, path, body, data)
+    }
 
     fn request_with_body_and_query<B, Q, R>(
         &self,

--- a/proxmox-api/src/clients/reqwest.rs
+++ b/proxmox-api/src/clients/reqwest.rs
@@ -201,36 +201,18 @@ impl Client {
 impl crate::client::Client for Client {
     type Error = Error;
 
-    async fn upload<B, R>(&self, path: &str, body: &B, data: Vec<u8>) -> Result<R, Error>
+    async fn upload<B, R>(&self, path: &str, body: B, data: Vec<u8>) -> Result<R, Error>
     where
-        B: Serialize,
+        B: IntoIterator<Item = (String, String)> + crate::client::AsFilename,
         R: DeserializeOwned,
     {
         log::debug!("POST (upload) {}", path);
 
-        // Serialize body to a JSON object so we can separate the filename
-        // (which becomes the file-name attribute on the binary part) from the
-        // remaining fields, which are sent as plain text form fields.
-        let fields = serde_json::to_value(body)
-            .map_err(|_| Error::Other("failed to serialize upload body"))?;
-        let fields = fields.as_object().ok_or(Error::Other(
-            "upload params must serialize to a JSON object",
-        ))?;
-
-        let filename = fields
-            .get("filename")
-            .and_then(|v| v.as_str())
-            .ok_or(Error::Other("upload params missing filename field"))?
-            .to_string();
+        let filename = body.as_filename();
 
         let mut form = reqwest::multipart::Form::new();
-        for (key, value) in fields {
-            if key == "filename" {
-                continue;
-            }
-            if let Some(s) = value.as_str() {
-                form = form.text(key.clone(), s.to_string());
-            }
+        for (key, value) in body {
+            form = form.text(key, value);
         }
 
         let file_part = reqwest::multipart::Part::bytes(data)

--- a/proxmox-api/src/clients/reqwest.rs
+++ b/proxmox-api/src/clients/reqwest.rs
@@ -52,6 +52,37 @@ fn extract_message(body: &str) -> String {
         .unwrap_or_else(|| body.to_string())
 }
 
+async fn parse_response<R: serde::de::DeserializeOwned>(
+    response: reqwest::Response,
+) -> Result<R, Error> {
+    let response_status = response.status();
+    let json_data = response.bytes().await?;
+    let json_str = std::str::from_utf8(&json_data).map_err(|_| Error::ResponseWasNotString)?;
+
+    log::debug!("JSON response: {json_str}");
+
+    if response_status != StatusCode::OK {
+        return Err(Error::UnknownFailure(
+            response_status,
+            Some(extract_message(json_str)),
+        ));
+    }
+
+    let result: Response<R> =
+        serde_json::from_str(json_str).map_err(|e| Error::DecodingFailed(json_str.into(), e))?;
+
+    if let Some(data) = result.data {
+        Ok(data)
+    } else if let Some(errors) = result.errors {
+        Err(Error::EncounteredErrors(errors))
+    } else {
+        Err(Error::UnknownFailure(
+            response_status,
+            Some(extract_message(json_str)),
+        ))
+    }
+}
+
 impl From<reqwest::Error> for Error {
     fn from(value: reqwest::Error) -> Self {
         Self::Reqwest(value)
@@ -170,6 +201,50 @@ impl Client {
 impl crate::client::Client for Client {
     type Error = Error;
 
+    async fn upload<B, R>(&self, path: &str, body: &B, data: Vec<u8>) -> Result<R, Error>
+    where
+        B: Serialize,
+        R: DeserializeOwned,
+    {
+        log::debug!("POST (upload) {}", path);
+
+        // Serialize body to a JSON object so we can separate the filename
+        // (which becomes the file-name attribute on the binary part) from the
+        // remaining fields, which are sent as plain text form fields.
+        let fields = serde_json::to_value(body)
+            .map_err(|_| Error::Other("failed to serialize upload body"))?;
+        let fields = fields.as_object().ok_or(Error::Other(
+            "upload params must serialize to a JSON object",
+        ))?;
+
+        let filename = fields
+            .get("filename")
+            .and_then(|v| v.as_str())
+            .ok_or(Error::Other("upload params missing filename field"))?
+            .to_string();
+
+        let mut form = reqwest::multipart::Form::new();
+        for (key, value) in fields {
+            if key == "filename" {
+                continue;
+            }
+            if let Some(s) = value.as_str() {
+                form = form.text(key.clone(), s.to_string());
+            }
+        }
+
+        let file_part = reqwest::multipart::Part::bytes(data)
+            .file_name(filename)
+            .mime_str("application/octet-stream")
+            .expect("known-valid MIME type");
+        form = form.part("filename", file_part);
+
+        let request = self.client.request(Method::POST, self.route(path));
+        let response = self.append_headers(request.multipart(form)).send().await?;
+
+        parse_response(response).await
+    }
+
     async fn request_with_body_and_query<B, Q, R>(
         &self,
         method: crate::client::Method,
@@ -209,33 +284,7 @@ impl crate::client::Client for Client {
 
         let response = self.append_headers(request).send().await?;
 
-        let response_status = response.status();
-
-        let json_data = response.bytes().await?;
-        let json_str = std::str::from_utf8(&json_data).map_err(|_| Error::ResponseWasNotString)?;
-
-        log::debug!("JSON response: {json_str}");
-
-        if response_status != StatusCode::OK {
-            return Err(Error::UnknownFailure(
-                response_status,
-                Some(extract_message(json_str)),
-            ));
-        }
-
-        let result: Response<R> = serde_json::from_str(json_str)
-            .map_err(|e| Error::DecodingFailed(json_str.into(), e))?;
-
-        if let Some(data) = result.data {
-            Ok(data)
-        } else if let Some(errors) = result.errors {
-            Err(Error::EncounteredErrors(errors))
-        } else {
-            Err(Error::UnknownFailure(
-                response_status,
-                Some(extract_message(json_str)),
-            ))
-        }
+        parse_response(response).await
     }
 }
 

--- a/proxmox-api/src/generated/nodes/node/storage/storage/upload.rs
+++ b/proxmox-api/src/generated/nodes/node/storage/storage/upload.rs
@@ -23,7 +23,7 @@ where
     #[doc = "Permission check: perm(\"/storage/{storage}\", [\"Datastore.AllocateTemplate\"])"]
     pub async fn post(&self, params: PostParams, data: Vec<u8>) -> Result<String, T::Error> {
         let path = self.path.to_string();
-        self.client.upload(&path, &params, data).await
+        self.client.upload(&path, params, data).await
     }
 }
 impl PostParams {

--- a/proxmox-api/src/generated/nodes/node/storage/storage/upload.rs
+++ b/proxmox-api/src/generated/nodes/node/storage/storage/upload.rs
@@ -21,9 +21,9 @@ where
     #[doc = "Upload templates, ISO images, OVAs and VM images."]
     #[doc = ""]
     #[doc = "Permission check: perm(\"/storage/{storage}\", [\"Datastore.AllocateTemplate\"])"]
-    pub async fn post(&self, params: PostParams) -> Result<String, T::Error> {
+    pub async fn post(&self, params: PostParams, data: Vec<u8>) -> Result<String, T::Error> {
         let path = self.path.to_string();
-        self.client.post(&path, &params).await
+        self.client.upload(&path, &params, data).await
     }
 }
 impl PostParams {

--- a/proxmox-api/src/lib.rs
+++ b/proxmox-api/src/lib.rs
@@ -9,6 +9,9 @@ mod generated;
 #[allow(unused)]
 pub use generated::*;
 
+#[cfg(feature = "nodes")]
+mod specialized;
+
 #[cfg(feature = "reqwest-client")]
 mod clients;
 

--- a/proxmox-api/src/specialized.rs
+++ b/proxmox-api/src/specialized.rs
@@ -12,11 +12,20 @@ impl IntoIterator for PostParams {
     type IntoIter = std::vec::IntoIter<(String, String)>;
 
     fn into_iter(self) -> Self::IntoIter {
+        let PostParams {
+            content,
+            checksum,
+            checksum_algorithm,
+            filename: _,
+            tmpfilename,
+            additional_properties,
+        } = self;
+
         let mut fields = Vec::new();
 
         fields.push((
             "content".to_string(),
-            match self.content {
+            match content {
                 Content::Import => "import",
                 Content::Iso => "iso",
                 Content::Vztmpl => "vztmpl",
@@ -24,11 +33,11 @@ impl IntoIterator for PostParams {
             .to_string(),
         ));
 
-        if let Some(checksum) = self.checksum {
+        if let Some(checksum) = checksum {
             fields.push(("checksum".to_string(), checksum));
         }
 
-        if let Some(algo) = self.checksum_algorithm {
+        if let Some(algo) = checksum_algorithm {
             fields.push((
                 "checksum-algorithm".to_string(),
                 match algo {
@@ -43,14 +52,14 @@ impl IntoIterator for PostParams {
             ));
         }
 
-        if let Some(tmpfilename) = self.tmpfilename {
+        if let Some(tmpfilename) = tmpfilename {
             fields.push((
                 "tmpfilename".to_string(),
                 tmpfilename.get_value().to_string(),
             ));
         }
 
-        for (k, v) in self.additional_properties {
+        for (k, v) in additional_properties {
             if let Some(s) = v.as_str() {
                 fields.push((k, s.to_string()));
             }

--- a/proxmox-api/src/specialized.rs
+++ b/proxmox-api/src/specialized.rs
@@ -1,0 +1,61 @@
+use crate::nodes::node::storage::storage::upload::{ChecksumAlgorithm, Content, PostParams};
+use crate::types::bounded_string::BoundedString;
+
+impl crate::client::AsFilename for PostParams {
+    fn as_filename(&self) -> String {
+        self.filename.get_value().to_string()
+    }
+}
+
+impl IntoIterator for PostParams {
+    type Item = (String, String);
+    type IntoIter = std::vec::IntoIter<(String, String)>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        let mut fields = Vec::new();
+
+        fields.push((
+            "content".to_string(),
+            match self.content {
+                Content::Import => "import",
+                Content::Iso => "iso",
+                Content::Vztmpl => "vztmpl",
+            }
+            .to_string(),
+        ));
+
+        if let Some(checksum) = self.checksum {
+            fields.push(("checksum".to_string(), checksum));
+        }
+
+        if let Some(algo) = self.checksum_algorithm {
+            fields.push((
+                "checksum-algorithm".to_string(),
+                match algo {
+                    ChecksumAlgorithm::Md5 => "md5",
+                    ChecksumAlgorithm::Sha1 => "sha1",
+                    ChecksumAlgorithm::Sha224 => "sha224",
+                    ChecksumAlgorithm::Sha256 => "sha256",
+                    ChecksumAlgorithm::Sha384 => "sha384",
+                    ChecksumAlgorithm::Sha512 => "sha512",
+                }
+                .to_string(),
+            ));
+        }
+
+        if let Some(tmpfilename) = self.tmpfilename {
+            fields.push((
+                "tmpfilename".to_string(),
+                tmpfilename.get_value().to_string(),
+            ));
+        }
+
+        for (k, v) in self.additional_properties {
+            if let Some(s) = v.as_str() {
+                fields.push((k, s.to_string()));
+            }
+        }
+
+        fields.into_iter()
+    }
+}


### PR DESCRIPTION
While the current generator implementation generates a client for the [storage/upload](https://pve.proxmox.com/pve-docs/api-viewer/#/nodes/{node}/storage/{storage}/upload) endpoint, it isn't functional. `UploadClient::PostParams` has no field for passing any file content. Furthermore, `UploadClient::post` calls `self.client.post`, which sends a URL-encoded body. Proxmox expects a `multipart/form-data` request for file uploads.

This patch adds functionality for uploading files to Proxmox as follows:

- generator: checks if an endpoint is an `upload` endpoint. If so, add `data: Vec<u8>` to the parameter list and call `self.client.upload`. With the latest Proxmox VE API, this only affects the storage/upload endpoint.
- `Client` trait: adds `Client::upload` to signature.
- clients/reqwest.rs: implements `Client::upload` to fulfill the updated `Client` trait. Move response parsing to a new `parse_response` helper function in order to prevent unnecessary code duplication.
- proxmox-api/Cargo.toml: add `multipart` feature as `reqwest` dependency.

These changes have been tested successfully on Proxmox VE 9.1.1.